### PR TITLE
Ruby 2.0

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -25,11 +25,13 @@ module Resqued
     #
     # Runs in the master process.
     def exec
-      ENV['RESQUED_SOCKET']      = @socket.fileno.to_s
+      socket_fd = @socket.to_i
+      ENV['RESQUED_SOCKET']      = socket_fd.to_s
       ENV['RESQUED_CONFIG_PATH'] = @config_paths.join(':')
       ENV['RESQUED_STATE']       = (@running_workers.map { |r| "#{r[:pid]}|#{r[:queue]}" }.join('||'))
       ENV['RESQUED_LISTENER_ID'] = @listener_id.to_s
-      Kernel.exec('resqued-listener')
+      # This may not work in rubies earlier than 1.9.
+      Kernel.exec('resqued-listener', socket_fd => socket_fd)
     end
 
     # Public: Given args from #exec, start this listener.


### PR DESCRIPTION
In ruby 2.0, you have to tell `Kernel.exec` which files/sockets to keep open. Also, some apps boot up slower than others, and it would be nice to know that the listener process is starting, and not just another mini-master.
