### PR TITLE
document resque compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This time, you'd end up with something similar to this:
 
 ## Compatibility with Resque
 
-Resqued does not automatically split comma-seperated lists of queues in
+Resqued does not automatically split comma-separated lists of queues in
 environment variables like Resque does. To continue using comma-separated
 lists, split them in your resqued config file:
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ This time, you'd end up with something similar to this:
 
 * `:interval` - The interval to pass to `Resque::Worker#run`.
 
+## Compatibility with Resque
+
+Resqued does not automatically split comma-seperated lists of queues in
+environment variables like Resque does. To continue using comma-separated
+lists, split them in your resqued config file:
+
+    queue (ENV["QUEUE"] || "*").split(',')
+
 ## Loading your application
 
 An advantage of using resqued (over `rake resque:work`) is that you can load your application just once, before forking all the workers.


### PR DESCRIPTION
Resqued doesn't support the comma-separated lists of queues used by Resque. I'm fine with that decision, but it should be documented as an incompatibility with a possible solution.