### PR TITLE
Try not to lose workers

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -142,9 +142,15 @@ module Resqued
     def reap_workers(waitpidflags = 0)
       loop do
         worker_pid, status = Process.waitpid2(-1, waitpidflags)
-        return :none_ready if worker_pid.nil?
-        finish_worker(worker_pid, status)
-        report_to_master("-#{worker_pid}")
+        if worker_pid.nil?
+          return :none_ready
+        elsif status.exited?
+          log "Worker exited #{status}"
+          finish_worker(worker_pid, status)
+          report_to_master("-#{worker_pid}")
+        else
+          log "Worker reported #{status}"
+        end
       end
     rescue Errno::ECHILD
       # All done

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -88,6 +88,8 @@ module Resqued
     def kill(signal)
       Process.kill(signal.to_s, pid) if pid && @self_started
       @killed = true
+    rescue Errno::ESRCH => e
+      log "Can't kill #{pid}: #{e}"
     end
   end
 end


### PR DESCRIPTION
I think what's happening in #21 is that workers report something other than exit on waitpid2, and the listener stops caring about them. They wander off into the woods, but we do hear from them again. This might fix it?
