### PR TITLE
Don't hold onto old file handles.

### DIFF
--- a/lib/resqued/logging.rb
+++ b/lib/resqued/logging.rb
@@ -11,6 +11,9 @@ module Resqued
             File.open(path, 'a').tap do |f|
               f.sync = true
               f.close_on_exec = true
+              # Make sure we're not holding onto a stale filehandle.
+              $stdout.reopen(f)
+              $stderr.reopen(f)
             end
           else
             $stdout


### PR DESCRIPTION
When resqued's parent process binds a file to stdout and/or stderr, resqued keeps it open, even after it should release the file on `SIGHUP`. This fixes that by reopening stdout and stderr with the current logfile, if it's specified. This should also keep resqued from losing some log messages, if it was losing them.

cc @jnewland 
