### PR TITLE
Fix EXIT trap clearing in master

### DIFF
--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -235,7 +235,7 @@ module Resqued
     end
 
     def no_more_unexpected_exits
-      trap('EXIT', nil)
+      trap('EXIT', 'DEFAULT')
     end
 
     def yawn(duration)


### PR DESCRIPTION
Surfaced in https://github.com/github/enterprise2/issues/1793 (private, sorry).

Looks like passing `nil` isn't a supported way to clear a trap. Ruby assumes it's a callable, which results in an "undefined method 'call' for nil:NilClass" error being passed to at_exit hooks. This doesn't seem to propogate when there's no at_exit hook, which is why we're probably not seeing it in many environments.

You need to use 'IGNORE', 'DEFAULT', or pass an empty block instead. I chose to use 'DEFAULT' here.