### PR TITLE
Restart `KILL`ed workers

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -172,12 +172,10 @@ module Resqued
         worker_pid, status = Process.waitpid2(-1, waitpidflags)
         if worker_pid.nil?
           return :none_ready
-        elsif status.exited?
+        else
           log "Worker exited #{status}"
           finish_worker(worker_pid, status)
           report_to_master("-#{worker_pid}")
-        else
-          log "Worker reported #{status}"
         end
       end
     rescue Errno::ECHILD


### PR DESCRIPTION
If `status.exited?` is false, it's because the child was `SIGKILL`ed. In that case, we should still spin up a new worker, not just log its exit status.

Fixes #38 

cc @rtomayko 