### PR TITLE
Workaround truncated listener/worker proclines

### DIFF
--- a/exe/resqued
+++ b/exe/resqued
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-if ARGV == ['listener']
+if ARGV[0] == 'listener'
   require 'resqued/listener'
   Resqued::Listener.exec!
   exit 0

--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -40,7 +40,8 @@ module Resqued
       if start_pwd = Resqued::START_CTX['pwd']
         exec_opts[:chdir] = start_pwd
       end
-      Kernel.exec(Resqued::START_CTX['$0'], 'listener', exec_opts)
+      procline_buf = ' ' * 256 # make room for setproctitle
+      Kernel.exec(Resqued::START_CTX['$0'], 'listener', procline_buf, exec_opts)
     end
 
     # Public: Given args from #exec, start this listener.


### PR DESCRIPTION
Under Linux, max custom procline length can in some circumstances be limited to the original size of argv provided to execve(2). Because the listener process is exec'd with most information being passed in
environ and a fairly short argv (can be "ruby bin/resqued listener" in extreme cases), the listener and worker custom proclines end up being truncated like follows:

    $ ps axo args | grep resqu[e]
    resqued-0.7.12 master [gen 1] [1 running] config/resqued/github-environment.rb config/resqued/github-staff.rb
    resqued-0.7.12 listener #1 4/4/4 [56d8c1a] [running] config/r
    resque-1.20.0: [56d8c1a] Waiting for lab_archive,lab_audit_lo
    resque-1.20.0: [56d8c1a] Waiting for lab_archive,lab_audit_lo
    resque-1.20.0: [56d8c1a] Waiting for lab_archive,lab_audit_lo
    resque-1.20.0: [56d8c1a] Waiting for lab_archive,lab_audit_lo

This patch adds an extra argument to the listener argv to pad out the maximum possible custom procline size. It's not a great solution but is the most reliable I've found. With it, I get full proclines as you'd expect.

/cc @spraints, @tmm1, https://github.com/github/github/pull/39908#issuecomment-88884011 (internal github issue)