### PR TITLE
Include MIT-LICENSE in gemspec

### DIFF
--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.authors = ["Matt Burke"]
   s.email   = 'spraints@gmail.com'
-  s.files   = Dir['lib/**/*', 'README.md', 'CHANGES.md', 'docs/**/*']
+  s.files   = Dir['lib/**/*', 'README.md', 'CHANGES.md', 'MIT-LICENSE', 'docs/**/*']
   s.test_files = Dir['spec/**/*']
   s.bindir  = 'exe'
   s.executables = %w(


### PR DESCRIPTION
The license should technically be included with any distribution of the code. So this adds the `MIT-LICENSE` to the gem.