### PR TITLE
nil @last_good_listener in Master#reap_all_listeners if that child was the one exiting

### DIFF
--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -198,6 +198,10 @@ module Resqued
             @listener_backoff.died
             @current_listener = nil
           end
+
+          if @last_good_listener && @last_good_listener.pid == lpid
+            @last_good_listener = nil
+          end
           dead_listener = listener_pids.delete(lpid)
           listener_status dead_listener, 'stop'
           dead_listener.dispose


### PR DESCRIPTION
I recently switch over to using resqued to start our resque workers and discovered that the master would die soon after being launched, but the workers would start.  This left the system in a state where I could not control the actual workers.

Looking at the logs, the master process was immediately processing a HUP signal after starting the listener in the main loop.  The listener would not be caught and killed in `read_listeners`, but would be caught existing in `reap_all_listeners`.  The next listener from the HUP would start and `listener_running` attempts to kill the `@last_good_listener` which doesn't exist anymore.

I added logic to `reap_all_listeners` to go ahead and nil `@last_good_listeners` if the pid matched the child exiting.  This solved my issue and now the master and listener processes correctly stay alive and I am able to control the worker pool.

I'm not quite sure where the HUP signal came into play on a new master start, but (without any testing) it may be a side-effect of bash's onhupexit option.  If set to true, bash will send HUPs to processes sent to the background which may be affecting the daemonize process.  The deploy process we use is over ssh and the start command would be the last one it runs before exiting.  The listener procline will show it is on generation 2, but otherwise everything looks to work as intended.


Below is the log file when the error happened.  The master exits when it captures an unexpected exit from the listener trying to send a signal to a process that doesn't exist anymore.

```                                                                                                                                                                          
[2015-10-22T14:32:13.961773 # 31064]  INFO Resqued::ListenerProxy -- Started listener 31067
[2015-10-22T14:32:13.962116 # 31067]  INFO Resqued::Listener -- exec: bin/resqued listener
[2015-10-22T14:32:14.041953 # 31064]  INFO Resqued::Master -- Restarting listener with new configuration and application.
[2015-10-22T14:32:14.081637 # 31064]  INFO Resqued::Master -- Listener exited pid 31067 SIGHUP (signal 1)
[2015-10-22T14:32:14.968463 # 31064]  INFO Resqued::ListenerProxy -- Started listener 31071
[2015-10-22T14:32:14.968942 # 31071]  INFO Resqued::Listener -- exec: bin/resqued listener
[2015-10-22T14:32:24.061877 # 31064]  INFO Resqued::ListenerProxy -- kill -QUIT 31067
[2015-10-22T14:32:24.062158 # 31064]  INFO Resqued::Master -- EXIT #<Errno::ESRCH: No such process>
```