### PR TITLE
Detach more completely on daemonize

### DIFF
--- a/lib/resqued/daemon.rb
+++ b/lib/resqued/daemon.rb
@@ -23,6 +23,9 @@ module Resqued
         exit
       else
         # master
+        STDIN.reopen "/dev/null"
+        STDOUT.reopen "/dev/null", "a"
+        STDERR.reopen "/dev/null", "a"
         rd.close
         @master.run(wr)
       end


### PR DESCRIPTION
stdin, stdout, and stderr could all still be attached to the original terminal after daemonizing. This branch makes them all reopen `/dev/null`.

cc #42