### PR TITLE
Quit faster on SIGQUIT

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -25,8 +25,7 @@ The Master process handles several signals.
 * `HUP`: Start a new listener. After it boots, kill the previous listener with `SIGQUIT`.
 * `USR2`: Pause processing. Kills the current listener, and does not start a replacement.
 * `CONT`: Resume processing. If there is no listener, start one. If there is a listener, send it `SIGCONT`.
-* `INT` or `TERM`: Kill the listener with the same signal and wait for it to exit.
-* `QUIT`: Kill the listener with `SIGQUIT` and exit immediately.
+* `QUIT`, `INT`, or `TERM`: Kill the listener with the same signal and wait for it to exit. If `--fast-exit` was specified, the master exits immediately without waiting for the listener to exit.
 * `CHLD`: Clean up any listeners that have exited. If the current listener exited
 
 ## Listener

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -25,7 +25,8 @@ The Master process handles several signals.
 * `HUP`: Start a new listener. After it boots, kill the previous listener with `SIGQUIT`.
 * `USR2`: Pause processing. Kills the current listener, and does not start a replacement.
 * `CONT`: Resume processing. If there is no listener, start one. If there is a listener, send it SIGCONT.
-* `QUIT`, `INT`, or `TERM`: Kill the listener with the same signal and wait for it to exit.
+* `INT` or `TERM`: Kill the listener with the same signal and wait for it to exit.
+* `QUIT`: Kill the listener with `SIGQUIT` and exit immediately.
 * `CHLD`: Clean up any listeners that have exited. If the current listener exited
 
 ## Listener

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -24,7 +24,7 @@ The Master process handles several signals.
 
 * `HUP`: Start a new listener. After it boots, kill the previous listener with `SIGQUIT`.
 * `USR2`: Pause processing. Kills the current listener, and does not start a replacement.
-* `CONT`: Resume processing. If there is no listener, start one. If there is a listener, send it SIGCONT.
+* `CONT`: Resume processing. If there is no listener, start one. If there is a listener, send it `SIGCONT`.
 * `INT` or `TERM`: Kill the listener with the same signal and wait for it to exit.
 * `QUIT`: Kill the listener with `SIGQUIT` and exit immediately.
 * `CHLD`: Clean up any listeners that have exited. If the current listener exited

--- a/exe/resqued
+++ b/exe/resqued
@@ -30,6 +30,10 @@ opts = OptionParser.new do |opts|
     test = true
   end
 
+  opts.on '--fast-exit', 'Exit quickly on SIGQUIT, SIGTERM' do
+    options[:fast_exit] = true
+  end
+
   opts.on '-p', '--pidfile PIDFILE', 'Store the pid of the master process in PIDFILE' do |v|
     options[:master_pidfile] = v
   end

--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -192,9 +192,9 @@ module Resqued
         line = @socket.readline
         finish_worker(line.to_i, nil)
       end
-    rescue EOFError, Errno::ECONNRESET
+    rescue EOFError, Errno::ECONNRESET => e
       @socket = nil
-      log "eof from master"
+      log "#{e.class.name} while reading from master"
       Process.kill(:QUIT, $$)
     end
 
@@ -237,8 +237,9 @@ module Resqued
     #     report_to_master("-12345")        # Worker process PID:12345 exited.
     def report_to_master(status)
       @socket.puts(status) if @socket
-    rescue Errno::EPIPE
+    rescue Errno::EPIPE => e
       @socket = nil
+      log "#{e.class.name} while writing to master"
       Process.kill(:QUIT, $$) # If the master is gone, LIFE IS NOW MEANINGLESS.
     end
 

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -20,6 +20,7 @@ module Resqued
       @config_paths = options.fetch(:config_paths)
       @pidfile      = options.fetch(:master_pidfile) { nil }
       @status_pipe  = options.fetch(:status_pipe) { nil }
+      @fast_exit    = options.fetch(:fast_exit) { false }
       @listener_backoff = Backoff.new
       @listeners_created = 0
     end
@@ -66,7 +67,7 @@ module Resqued
         when :INT, :TERM, :QUIT
           log "Shutting down..."
           kill_all_listeners(signal)
-          wait_for_workers unless signal == :QUIT
+          wait_for_workers unless @fast_exit
           break
         end
       end

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -66,7 +66,7 @@ module Resqued
         when :INT, :TERM, :QUIT
           log "Shutting down..."
           kill_all_listeners(signal)
-          wait_for_workers
+          wait_for_workers unless signal == :QUIT
           break
         end
       end

--- a/spec/resqued/sleepy_spec.rb
+++ b/spec/resqued/sleepy_spec.rb
@@ -27,4 +27,8 @@ describe Resqued::Sleepy do
   it 'does not sleep if duration is negative' do
     expect { yawn(0) }.to run_for(0.0)
   end
+
+  it 'sleeps if io is nil' do
+    expect { yawn(0.5, nil) }.to run_for(0.5)
+  end
 end


### PR DESCRIPTION
In our prod environment, we've changed from using SIGHUP to roll over the resqued pool to using SIGQUIT + spinning up a new resqued master+listener+workers. The service manager waits a short time for the process to exit before killing it forcefully. Resqued's master doesn't exit until all listeners have exited. A listener doesn't exit until all of its workers have exited. So, if there's a slow job running, the master process can take more than 10s to exit. This results in the service manager doing `kill -9` on the master process, which can lead to `ECONNRESET`, which was unexpected before #44.

This branch adds a `--fast-exit` option to `resqued` that tells the master process to exit immediately on a terminal signal, rather than waiting for the listener to exit.

One reason that the master process didn't exit immediately is because it's coordinating between different generations of listeners, so that new resque workers aren't started until their counterparts  from the previous generation stop. When resqued is shutting down, the coordination is unnecessary, so it's fine for the master to exit before all the workers have exited. I made the fast exit behavior optional, though, so that operators can choose what works best for them.

cc @vmg @jnunemaker