### PR TITLE
Worker: use Integer where available

### DIFF
--- a/lib/resqued/config/worker.rb
+++ b/lib/resqued/config/worker.rb
@@ -101,7 +101,7 @@ module Resqued
         case
         when value.nil?
           @pool_size
-        when value.is_a?(Fixnum)
+        when value.is_a?(1.class)
           value < @pool_size ? value : @pool_size
         when value.is_a?(Float) && value >= 0.0 && value <= 1.0
           (@pool_size * value).to_i


### PR DESCRIPTION
Ruby's `Fixnum` and `Bignum` classes have been unified since 2.4.0: https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/ The old constants still exist, but accessing them now prints deprecation warnings.

This patch works around this by using `1.class` to dynamically access the default integer class and avoid the deprecation warning.