### PR TITLE
Add config for worker class and multiple pools

### DIFF
--- a/lib/resqued/config/worker.rb
+++ b/lib/resqued/config/worker.rb
@@ -10,7 +10,7 @@ module Resqued
       # Public.
       def initialize(options = {})
         options = options.dup
-        @worker_class = options.delete(:worker_class) || Resqued::Worker
+        @resqued_worker_class = options.delete(:resqued_worker_class) || Resqued::Worker
         @worker_options = options
         @workers = []
       end
@@ -23,7 +23,7 @@ module Resqued
         queues = queues.flatten
         queues = ['*'] if queues.empty?
         queues = queues.shuffle if options.delete(:shuffle_queues)
-        @workers << @worker_class.new(options.merge(@worker_options).merge(:queues => queues))
+        @workers << @resqued_worker_class.new(options.merge(@worker_options).merge(:queues => queues))
       end
 
       # DSL: Set up a pool of workers. Define queues for the members of the pool with `queue`.

--- a/spec/resqued/config/worker_spec.rb
+++ b/spec/resqued/config/worker_spec.rb
@@ -132,6 +132,20 @@ describe Resqued::Config::Worker do
     end
   end
 
+  context 'multiple worker pools' do
+    let(:config) { <<-END_CONFIG }
+      worker_pool 2, 'a', 'b', 'c', :interval => 1
+      worker_pool 2, 'a', 'b', 'c', :interval => 1, :worker_class => FakeResqueWoker
+    END_CONFIG
+    it { expect(result.size).to eq(4) }
+    it { expect(result).to eq([
+      { :queues => ['a', 'b', 'c'], :interval => 1 },
+      { :queues => ['a', 'b', 'c'], :interval => 1 },
+      { :queues => ['a', 'b', 'c'], :interval => 1, :worker_class => FakeResqueWoker },
+      { :queues => ['a', 'b', 'c'], :interval => 1, :worker_class => FakeResqueWoker },
+    ]) }
+  end
+
   context 'multiple worker configs' do
     let(:config) { <<-END_CONFIG }
       worker 'one'


### PR DESCRIPTION
This PR extends resqued configuration to 1) allow specifying a worker class other than `Resque::Worker` and 2) allow multiple worker pools. For example, the following config should create 20 workers, 10 of which use `AnotherQueue::Worker` to process jobs.

```
worker_pool 10
worker_pool 10, worker_class: AnotherQueue::Worker
queue "test"
```

The goal with these changes is to continue using resqued while gradually transitioning from resque to an alternate queueing backend.

cc @github/data-pipelines @spraints 