### PR TITLE
Add worker_factory DSL option

### DIFF
--- a/lib/resqued/config/dsl.rb
+++ b/lib/resqued/config/dsl.rb
@@ -20,6 +20,10 @@ module Resqued
       def worker_pool(count, *queues_and_options)
       end
 
+      # Public: Define a factory Proc that creates Resque::Workers
+      def worker_factory(&block)
+      end
+
       # Public: Define the queues worked by members of the worker pool.
       def queue(*queues)
       end

--- a/lib/resqued/config/worker.rb
+++ b/lib/resqued/config/worker.rb
@@ -36,6 +36,14 @@ module Resqued
         queues.each { |q| queue q }
       end
 
+      # DSL: Define a factory Proc used to create Resque::Workers. The factory
+      # Proc receives a list of queues as an argument.
+      #
+      #    worker_factory { |queues| Resque::Worker.new(*queues) }
+      def worker_factory(&block)
+        @worker_options.merge!(worker_factory: block)
+      end
+
       # DSL: Define a queue for the worker_pool to work from.
       #
       #     queue 'one'

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -8,11 +8,14 @@ module Resqued
   class Worker
     include Resqued::Logging
 
+    DEFAULT_WORKER_FACTORY = ->(queues) { Resque::Worker.new(*queues) }
+
     def initialize(options)
       @queues = options.fetch(:queues)
       @config = options.fetch(:config)
       @interval = options[:interval]
       @backoff = Backoff.new
+      @worker_factory = options.fetch(:worker_factory, DEFAULT_WORKER_FACTORY)
       @pids = []
     end
 
@@ -80,7 +83,7 @@ module Resqued
         Resqued::Listener::ALL_SIGNALS.each { |signal| trap(signal, 'DEFAULT') }
         trap(:QUIT) { exit! 0 } # If we get a QUIT during boot, just spin back down.
         $0 = "STARTING RESQUE FOR #{queues.join(',')}"
-        resque_worker = Resque::Worker.new(*queues)
+        resque_worker = @worker_factory.call(queues)
         resque_worker.term_child = true if resque_worker.respond_to?('term_child=')
         Resque.redis.client.reconnect
         @config.after_fork(resque_worker)

--- a/spec/resqued/config/worker_spec.rb
+++ b/spec/resqued/config/worker_spec.rb
@@ -140,6 +140,29 @@ describe Resqued::Config::Worker do
     it { expect(result[3]).to eq(:queues => ['*']) }
   end
 
+  context 'worker factory' do
+    let(:config) { <<-END_CONFIG }
+      worker_factory { |queues| queues }
+      worker 'a'
+    END_CONFIG
+
+    it { expect(result.size).to eq(1) }
+    it { expect(result[0].reject { |k, _| k == :worker_factory}).to eq(:queues => ['a']) }
+    it { expect(result[0][:worker_factory].call(result[0][:queues])).to eq(['a']) }
+  end
+
+  context 'worker factory with pool' do
+    let(:config) { <<-END_CONFIG }
+      worker_factory { |queues| queues }
+      worker_pool 1
+      queue 'a'
+    END_CONFIG
+
+    it { expect(result.size).to eq(1) }
+    it { expect(result[0].reject { |k, _| k == :worker_factory}).to eq(:queues => ['a']) }
+    it { expect(result[0][:worker_factory].call(result[0][:queues])).to eq(['a']) }
+  end
+
   context 'with default options' do
     let(:evaluator) { described_class.new(:worker_class => FakeWorker, :config => 'something') }
     let(:config) { <<-END_CONFIG }


### PR DESCRIPTION
As a followup to https://github.com/spraints/resqued/pull/47, this PR adds a `worker_factory` DSL option to allow configurations to override the `Resque::Worker` class. 

cc @github/data-pipelines @spraints 