### PR TITLE
hash queue key to limit its size to 40 chars

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -32,7 +32,7 @@ module Resqued
       socket_fd = @socket.to_i
       ENV['RESQUED_SOCKET']      = socket_fd.to_s
       ENV['RESQUED_CONFIG_PATH'] = @config_paths.join(':')
-      ENV['RESQUED_STATE']       = (@old_workers.map { |r| "#{r[:pid]}|#{r[:queue]}" }.join('||'))
+      ENV['RESQUED_STATE']       = (@old_workers.map { |r| "#{r[:pid]}|#{r[:queue_key]}" }.join('||'))
       ENV['RESQUED_LISTENER_ID'] = @listener_id.to_s
       ENV['RESQUED_MASTER_VERSION'] = Resqued::VERSION
       log "exec: #{Resqued::START_CTX['$0']} listener"
@@ -54,7 +54,7 @@ module Resqued
         options[:config_paths] = path.split(':')
       end
       if state = ENV['RESQUED_STATE']
-        options[:old_workers] = state.split('||').map { |s| Hash[[:pid,:queue].zip(s.split('|'))] }
+        options[:old_workers] = state.split('||').map { |s| Hash[[:pid,:queue_key].zip(s.split('|'))] }
       end
       if listener_id = ENV['RESQUED_LISTENER_ID']
         options[:listener_id] = listener_id
@@ -223,7 +223,7 @@ module Resqued
     def init_workers(config)
       @workers = config.build_workers
       @old_workers.each do |running_worker|
-        if blocked_worker = @workers.detect { |worker| worker.idle? && worker.queue_key == running_worker[:queue] }
+        if blocked_worker = @workers.detect { |worker| worker.idle? && worker.queue_key == running_worker[:queue_key] }
           blocked_worker.wait_for(running_worker[:pid].to_i)
         end
       end

--- a/lib/resqued/listener_proxy.rb
+++ b/lib/resqued/listener_proxy.rb
@@ -57,7 +57,7 @@ module Resqued
 
     # Public: Get the list of workers running from this listener.
     def running_workers
-      worker_pids.map { |pid, queue| { :pid => pid, :queue => queue } }
+      worker_pids.map { |pid, queue_key| { :pid => pid, :queue_key => queue_key } }
     end
 
     # Private: Map worker pids to queue names

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -1,4 +1,5 @@
 require 'resque'
+require 'digest'
 
 require 'resqued/backoff'
 require 'resqued/logging'
@@ -43,7 +44,7 @@ module Resqued
 
     # Public: A string that compares if this worker is equivalent to a worker in another Resqued::Listener.
     def queue_key
-      queues.sort.join(';')
+      Digest::SHA256.hexdigest(queues.sort.join(';'))
     end
 
     # Public: Claim this worker for another listener's worker.


### PR DESCRIPTION
A resque worker can process a large number of queues. If there are many
many workers with large queues, then the [`RESQUED_STATE` environment
variable](https://github.com/spraints/resqued/blob/5d95bdfe009ce99ae745af552b6446b1465a3eb8/lib/resqued/listener.rb#L35) can become very large as well. The environment variable can
becomes so large that it exceeds the maximum length of arguments for [a
new process](https://github.com/spraints/resqued/blob/5d95bdfe009ce99ae745af552b6446b1465a3eb8/lib/resqued/listener.rb#L44). This will cause an E2BIG error.

Fix this problem by hashing the queue key to limits its size to 40 chars.