### PR TITLE
Re-exec master on reload (SIGHUP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 bundler_args: --without development
 cache: bundler
 rvm:
-  - "2.0"
-  # - "2.1" # uses a bundler that has this bug: https://github.com/bundler/bundler/issues/3558
   - "2.2"
   - "2.3"
   - "2.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   # - "2.1" # uses a bundler that has this bug: https://github.com/bundler/bundler/issues/3558
   - "2.2"
   - "2.3"
+  - "2.4"
+  - "2.5"
+  - "2.6"
 gemfile:
   - gemfiles/resque-min
   - gemfiles/resque-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - "2.4"
   - "2.5"
   - "2.6"
+bundler_args: "--binstubs bin"
 gemfile:
   - gemfiles/resque-min
   - gemfiles/resque-latest

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,12 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.rspec_opts = '-f doc'
 end
 
-task :default => :spec
+desc "Test daemon start/restart/stop"
+task :test_restart do
+  sh "spec/test_restart.sh"
+end
+
+desc "Run all tests"
+task :tests => [:spec, :test_restart]
+
+task :default => :tests

--- a/exe/resqued
+++ b/exe/resqued
@@ -51,12 +51,15 @@ end
 opts.parse!
 options[:config_paths] = ARGV
 
-if options[:config_paths].size == 0
-  puts opts
-  exit 1
+def require_config_paths!(options)
+  if options[:config_paths].size == 0
+    puts opts
+    exit 1
+  end
 end
 
 if test
+  require_config_paths! options
   require 'resqued/config'
   workers = Resqued::Config.new(options[:config_paths]).build_workers
   puts "Workers defined in #{options[:config_paths].join(' ')}"
@@ -64,6 +67,7 @@ if test
     puts "#{index + 1}: #{worker.queues.join(',')}"
   end
 else
+  require_config_paths! options
   require 'resqued'
   Resqued.capture_start_ctx!
   state = Resqued::MasterState.new(options)

--- a/exe/resqued
+++ b/exe/resqued
@@ -66,7 +66,8 @@ if test
 else
   require 'resqued'
   Resqued.capture_start_ctx!
-  resqued = Resqued::Master.new(options)
+  state = Resqued::MasterState.new(options)
+  resqued = Resqued::Master.new(state)
   if daemonize
     require 'resqued/daemon'
     resqued = Resqued::Daemon.new(resqued)

--- a/exe/resqued
+++ b/exe/resqued
@@ -8,7 +8,7 @@ end
 
 require 'optparse'
 
-options = {}
+options = {:exec_on_hup => true}
 daemonize = false
 test = false
 
@@ -47,8 +47,8 @@ opts = OptionParser.new do |opts|
     daemonize = true
   end
 
-  opts.on '--exec-on-hup', 'Re-exec the master process on SIGHUP' do
-    options[:exec_on_hup] = true
+  opts.on '--no-exec-on-hup', 'Do not re-exec the master process on SIGHUP' do
+    options[:exec_on_hup] = false
   end
 
   opts.on '--replace FILE', '(internal)' do |v|

--- a/exe/resqued
+++ b/exe/resqued
@@ -46,6 +46,10 @@ opts = OptionParser.new do |opts|
   opts.on '-D', '--daemonize', 'Run daemonized in the background' do
     daemonize = true
   end
+
+  opts.on '--exec-on-hup', 'Re-exec the master process on SIGHUP' do
+    options[:exec_on_hup] = true
+  end
 end
 
 opts.parse!

--- a/exe/resqued
+++ b/exe/resqued
@@ -50,6 +50,10 @@ opts = OptionParser.new do |opts|
   opts.on '--exec-on-hup', 'Re-exec the master process on SIGHUP' do
     options[:exec_on_hup] = true
   end
+
+  opts.on '--replace FILE', '(internal)' do |v|
+    options[:master_state] = v
+  end
 end
 
 opts.parse!
@@ -71,11 +75,16 @@ if test
     puts "#{index + 1}: #{worker.queues.join(',')}"
   end
 else
-  require_config_paths! options
   require 'resqued'
-  Resqued.capture_start_ctx!
   state = Resqued::MasterState.new
-  state.init(options)
+  if options[:master_state]
+    Resqued::Logging.logger.info "Resuming master from #{options[:master_state]}"
+    Resqued::ExecOnHUP.restore_state(state, options[:master_state])
+  else
+    require_config_paths! options
+    Resqued.capture_start_ctx!
+    state.init(options)
+  end
   resqued = Resqued::Master.new(state)
   if daemonize
     require 'resqued/daemon'

--- a/exe/resqued
+++ b/exe/resqued
@@ -74,7 +74,8 @@ else
   require_config_paths! options
   require 'resqued'
   Resqued.capture_start_ctx!
-  state = Resqued::MasterState.new(options)
+  state = Resqued::MasterState.new
+  state.init(options)
   resqued = Resqued::Master.new(state)
   if daemonize
     require 'resqued/daemon'

--- a/exe/resqued
+++ b/exe/resqued
@@ -8,7 +8,7 @@ end
 
 require 'optparse'
 
-options = {:exec_on_hup => true}
+options = {exec_on_hup: true}
 daemonize = false
 test = false
 

--- a/exe/resqued
+++ b/exe/resqued
@@ -59,7 +59,7 @@ end
 opts.parse!
 options[:config_paths] = ARGV
 
-def require_config_paths!(options)
+def require_config_paths!(options, opts)
   if options[:config_paths].size == 0
     puts opts
     exit 1
@@ -67,7 +67,7 @@ def require_config_paths!(options)
 end
 
 if test
-  require_config_paths! options
+  require_config_paths! options, opts
   require 'resqued/config'
   workers = Resqued::Config.new(options[:config_paths]).build_workers
   puts "Workers defined in #{options[:config_paths].join(' ')}"
@@ -81,7 +81,7 @@ else
     Resqued::Logging.logger.info "Resuming master from #{options[:master_state]}"
     Resqued::ExecOnHUP.restore_state(state, options[:master_state])
   else
-    require_config_paths! options
+    require_config_paths! options, opts
     Resqued.capture_start_ctx!
     state.init(options)
   end

--- a/exe/resqued-listener
+++ b/exe/resqued-listener
@@ -1,6 +1,0 @@
-#!/usr/bin/env ruby
-
-puts "resqued-listener is deprecated and will be removed."
-puts "Stop and start the master process to remove your dependence on resqued-listener."
-require 'resqued/listener'
-Resqued::Listener.exec!

--- a/lib/resqued/exec_on_hup.rb
+++ b/lib/resqued/exec_on_hup.rb
@@ -1,3 +1,4 @@
+require "tempfile"
 require "yaml"
 
 module Resqued

--- a/lib/resqued/exec_on_hup.rb
+++ b/lib/resqued/exec_on_hup.rb
@@ -1,0 +1,42 @@
+require "yaml"
+
+module Resqued
+  class ExecOnHUP
+    # Public: Replace the current master process with a new one, while preserving state.
+    def self.exec!(state)
+      exec Resqued::START_CTX['$0'], "--replace", store_state(state), exec_opts(state)
+    end
+
+    # Internal: Returns exec options for each open socket in 'state'.
+    def self.exec_opts(state)
+      exec_opts = {}
+      state.sockets.each do |sock|
+        exec_opts[sock.to_i] = sock
+      end
+      if pwd = Resqued::START_CTX['pwd']
+        exec_opts[:chdir] = pwd
+      end
+      return exec_opts
+    end
+
+    # Internal: Write out current state to a file, so that a new master can pick up from where we left off.
+    def self.store_state(state)
+      data = {version: Resqued::VERSION}
+      data[:start_ctx] = Resqued::START_CTX
+      data[:state] = state.to_h
+      
+      f = Tempfile.create "resqued-state"
+      f.write(YAML.dump(data))
+      f.close
+      return f.path
+    end
+
+    # Internal: Restore the master's state, and remove the state file.
+    def self.restore_state(state, path)
+      data = YAML.load(File.read(path))
+      Resqued::START_CTX.replace(data[:start_ctx] || {})
+      state.restore(data[:state])
+      File.unlink(path) rescue nil
+    end
+  end
+end

--- a/lib/resqued/listener_pool.rb
+++ b/lib/resqued/listener_pool.rb
@@ -29,9 +29,9 @@ module Resqued
     def start!
       listener_state = ListenerState.new
       listener_state.options = {
-        :config_paths => @master_state.config_paths,
-        :old_workers => map { |l| l.running_workers }.flatten,
-        :listener_id => next_listener_id,
+        config_paths: @master_state.config_paths,
+        old_workers: map { |l| l.running_workers }.flatten,
+        listener_id: next_listener_id,
       }
       listener = ListenerProxy.new(listener_state)
       listener.run

--- a/lib/resqued/listener_pool.rb
+++ b/lib/resqued/listener_pool.rb
@@ -9,6 +9,10 @@ module Resqued
     def initialize(master_state)
       @master_state = master_state
       @listener_proxies = {}
+      # If this master is replacing an old one, there will be listeners in the state already.
+      @master_state.listener_states.each do |pid, ls|
+        @listener_proxies[pid] = ListenerProxy.new(ls)
+      end
     end
 
     # Public: Iterate through all active ListenerProxy instances.

--- a/lib/resqued/listener_pool.rb
+++ b/lib/resqued/listener_pool.rb
@@ -1,0 +1,84 @@
+require "resqued/listener_proxy"
+require "resqued/listener_state"
+
+module Resqued
+  class ListenerPool
+    include Enumerable
+
+    # Public: Initialize a new pool, and store state in the given master's state.
+    def initialize(master_state)
+      @master_state = master_state
+    end
+
+    # Public: Iterate through all active ListenerProxy instances.
+    def each(&block)
+      @master_state.listener_pids.values.each(&block)
+    end
+
+    # Public: Number of active listeners.
+    def size
+      @master_state.listener_pids.values.size
+    end
+
+    # Public: Initialize a new listener, run it, and record it as the current listener. Returns its ListenerProxy.
+    def start!
+      listener_state = ListenerState.new
+      listener_state.options = {
+        :config_paths => @master_state.config_paths,
+        :old_workers => map { |l| l.running_workers }.flatten,
+        :listener_id => next_listener_id,
+      }
+      listener = ListenerProxy.new(listener_state)
+      listener.run
+      @master_state.listener_pids[listener.pid] = listener
+      @master_state.current_listener_pid = listener.pid
+      return listener
+    end
+
+    # Public: Remove the given pid from the set of known listeners, and return its ListenerProxy.
+    def delete(pid)
+      @master_state.listener_pids.delete(pid)
+    end
+
+    # Public: The current ListenerProxy, if available.
+    def current
+      @master_state.listener_pids[current_pid]
+    end
+
+    # Public: The pid of the current listener, if available.
+    def current_pid
+      @master_state.current_listener_pid
+    end
+
+    # Public: Don't consider the current listener to be current anymore.
+    def clear_current!
+      @master_state.current_listener_pid = nil
+    end
+
+    # Public: Change the current listener into the last good listener.
+    def cycle_current
+      @master_state.last_good_listener_pid = @master_state.current_listener_pid
+    end
+
+    # Public: The last good (previous current) ListenerProxy, if available.
+    def last_good
+      @master_state.listener_pids[last_good_pid]
+    end
+
+    # Public: The pid of the last good listener, if available.
+    def last_good_pid
+      @master_state.last_good_listener_pid
+    end
+
+    # Public: Forget which listener was the last good one.
+    def clear_last_good!
+      @master_state.last_good_listener_pid = nil
+    end
+
+    private
+
+    def next_listener_id
+      @master_state.listeners_created += 1
+    end
+  end
+end

--- a/lib/resqued/listener_pool.rb
+++ b/lib/resqued/listener_pool.rb
@@ -65,6 +65,7 @@ module Resqued
     # Public: Change the current listener into the last good listener.
     def cycle_current
       @master_state.last_good_listener_pid = @master_state.current_listener_pid
+      @master_state.current_listener_pid = nil
     end
 
     # Public: The last good (previous current) ListenerProxy, if available.

--- a/lib/resqued/listener_proxy.rb
+++ b/lib/resqued/listener_proxy.rb
@@ -10,41 +10,45 @@ module Resqued
     include Resqued::Logging
 
     # Public.
-    def initialize(options)
-      @options = options
+    def initialize(state)
+      @state = state
     end
+
+    attr_reader :state
 
     # Public: wrap up all the things, this object is going home.
     def dispose
-      if @master_socket
-        @master_socket.close
-        @master_socket = nil
+      if @state.master_socket
+        @state.master_socket.close
+        @state.master_socket = nil
       end
     end
 
     # Public: An IO to select on to check if there is incoming data available.
     def read_pipe
-      @master_socket
+      @state.master_socket
     end
 
     # Public: The pid of the running listener process.
-    attr_reader :pid
+    def pid
+      @state.pid
+    end
 
     # Public: Start the listener process.
     def run
       return if pid
       listener_socket, master_socket = UNIXSocket.pair
-      if @pid = fork
+      if @state.pid = fork
         # master
         listener_socket.close
         master_socket.close_on_exec = true
-        log "Started listener #{@pid}"
-        @master_socket = master_socket
+        log "Started listener #{@state.pid}"
+        @state.master_socket = master_socket
       else
         # listener
         master_socket.close
         Master::TRAPS.each { |signal| trap(signal, 'DEFAULT') rescue nil }
-        Listener.new(@options.merge(:socket => listener_socket)).exec
+        Listener.new(@state.options.merge(:socket => listener_socket)).exec
         exit
       end
     end
@@ -62,15 +66,15 @@ module Resqued
 
     # Private: Map worker pids to queue names
     def worker_pids
-      @worker_pids ||= {}
+      @state.worker_pids ||= {}
     end
 
     # Public: Check for updates on running worker information.
     def read_worker_status(options)
       on_activity = options[:on_activity]
-      until @master_socket.nil?
-        IO.select([@master_socket], nil, nil, 0) or return
-        case line = @master_socket.readline
+      until @state.master_socket.nil?
+        IO.select([@state.master_socket], nil, nil, 0) or return
+        case line = @state.master_socket.readline
         when /^\+(\d+),(.*)$/
           worker_pids[$1] = $2
           on_activity.worker_started($1) if on_activity
@@ -86,17 +90,17 @@ module Resqued
         end
       end
     rescue EOFError, Errno::ECONNRESET
-      @master_socket.close
-      @master_socket = nil
+      @state.master_socket.close
+      @state.master_socket = nil
     end
 
     # Public: Tell the listener process that a worker finished.
     def worker_finished(pid)
-      return if @master_socket.nil?
-      @master_socket.puts(pid)
+      return if @state.master_socket.nil?
+      @state.master_socket.puts(pid)
     rescue Errno::EPIPE
-      @master_socket.close
-      @master_socket = nil
+      @state.master_socket.close
+      @state.master_socket = nil
     end
   end
 end

--- a/lib/resqued/listener_proxy.rb
+++ b/lib/resqued/listener_proxy.rb
@@ -48,7 +48,7 @@ module Resqued
         # listener
         master_socket.close
         Master::TRAPS.each { |signal| trap(signal, 'DEFAULT') rescue nil }
-        Listener.new(@state.options.merge(:socket => listener_socket)).exec
+        Listener.new(@state.options.merge(socket: listener_socket)).exec
         exit
       end
     end

--- a/lib/resqued/listener_proxy_state.rb
+++ b/lib/resqued/listener_proxy_state.rb
@@ -1,0 +1,8 @@
+module Resqued
+  class ListenerProxyState
+    attr_accessor :master_socket
+    attr_accessor :options
+    attr_accessor :pid
+    attr_accessor :worker_pids
+  end
+end

--- a/lib/resqued/listener_state.rb
+++ b/lib/resqued/listener_state.rb
@@ -1,5 +1,5 @@
 module Resqued
-  class ListenerProxyState
+  class ListenerState
     attr_accessor :master_socket
     attr_accessor :options
     attr_accessor :pid

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -160,11 +160,11 @@ module Resqued
         # The last good listener is still running because we got another HUP before the new listener finished booting.
         # Keep the last_good_listener (where all the workers are) and kill the booting current_listener. We'll start a new one.
         kill_listener(:QUIT, @listeners.current)
+        # Indicate to `start_listener` that it should start a new listener.
+        @listeners.clear_current!
       else
         @listeners.cycle_current
       end
-      # Indicate to `start_listener` that it should start a new listener.
-      @listeners.clear_current!
     end
 
     def kill_listener(signal, listener)

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -103,14 +103,9 @@ module Resqued
       log "Error while counting objects: #{e}"
     end
 
-    # Private: Map listener pids to ListenerProxy objects.
-    def listener_pids
-      @state.listener_pids ||= {}
-    end
-
     # Private: All the ListenerProxy objects.
     def all_listeners
-      listener_pids.values
+      @state.listener_pids.values
     end
 
     def start_listener
@@ -125,7 +120,7 @@ module Resqued
       @state.current_listener.run
       listener_status @state.current_listener, 'start'
       @listener_backoff.started
-      listener_pids[@state.current_listener.pid] = @state.current_listener
+      @state.listener_pids[@state.current_listener.pid] = @state.current_listener
       write_procline
     end
 
@@ -212,7 +207,7 @@ module Resqued
           if @state.last_good_listener && @state.last_good_listener.pid == lpid
             @state.last_good_listener = nil
           end
-          dead_listener = listener_pids.delete(lpid)
+          dead_listener = @state.listener_pids.delete(lpid)
           listener_status dead_listener, 'stop'
           dead_listener.dispose
           write_procline
@@ -257,7 +252,7 @@ module Resqued
     end
 
     def write_procline
-      $0 = "#{procline_version} master [gen #{@state.listeners_created}] [#{listener_pids.size} running] #{ARGV.join(' ')}"
+      $0 = "#{procline_version} master [gen #{@state.listeners_created}] [#{@state.listener_pids.size} running] #{ARGV.join(' ')}"
     end
 
     def listener_status(listener, status)

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -20,7 +20,7 @@ module Resqued
 
     def initialize(state, options = {})
       @state = state
-      @status_pipe = options.fetch(:status_pipe) { nil }
+      @status_pipe = options.fetch(:status_pipe, nil)
       @listeners = ListenerPool.new(state)
       @listener_backoff = Backoff.new
     end

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -50,9 +50,13 @@ module Resqued
         when :INFO
           dump_object_counts
         when :HUP
-          reopen_logs
-          log "Restarting listener with new configuration and application."
-          prepare_new_listener
+          if @state.exec_on_hup
+            log "TODO - re-exec the master"
+          else
+            reopen_logs
+            log "Restarting listener with new configuration and application."
+            prepare_new_listener
+          end
         when :USR2
           log "Pause job processing"
           @state.paused = true

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -1,6 +1,6 @@
 require 'resqued/backoff'
 require 'resqued/listener_proxy'
-require 'resqued/listener_proxy_state'
+require 'resqued/listener_state'
 require 'resqued/logging'
 require 'resqued/master_state'
 require 'resqued/pidfile'
@@ -110,7 +110,7 @@ module Resqued
 
     def start_listener
       return if @state.current_listener || @listener_backoff.wait?
-      listener_state = ListenerProxyState.new
+      listener_state = ListenerState.new
       listener_state.options = {
         :config_paths => @state.config_paths,
         :old_workers => all_listeners.map { |l| l.running_workers }.flatten,

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -1,12 +1,16 @@
 module Resqued
   class MasterState
-    def initialize(options)
+    def initialize
+      @listeners_created = 0
+      @listener_states = {}
+    end
+
+    # Public: When starting fresh, from command-line options, assign the initial values.
+    def init(options)
       @config_paths = options.fetch(:config_paths)
       @exec_on_hup  = options.fetch(:exec_on_hup) { false }
       @fast_exit    = options.fetch(:fast_exit) { false }
       @pidfile      = options.fetch(:master_pidfile) { nil }
-      @listeners_created = 0
-      @listener_states = {}
     end
 
     attr_reader :config_paths

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -2,6 +2,7 @@ module Resqued
   class MasterState
     def initialize(options)
       @config_paths = options.fetch(:config_paths)
+      @exec_on_hup  = options.fetch(:exec_on_hup) { false }
       @fast_exit    = options.fetch(:fast_exit) { false }
       @pidfile      = options.fetch(:master_pidfile) { nil }
       @listeners_created = 0
@@ -9,6 +10,7 @@ module Resqued
 
     attr_reader :config_paths
     attr_accessor :current_listener
+    attr_reader :exec_on_hup
     attr_reader :fast_exit
     attr_accessor :last_good_listener
     attr_accessor :listeners_created

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -13,6 +13,51 @@ module Resqued
       @pidfile      = options.fetch(:master_pidfile) { nil }
     end
 
+    # Public: Restore state from a serialized form.
+    def restore(h)
+      @config_paths = h[:config_paths]
+      @current_listener_pid = h[:current_listener_pid]
+      @exec_on_hup = h[:exec_on_hup]
+      @fast_exit = h[:fast_exit]
+      @last_good_listener_pid = h[:last_good_listener_pid]
+      @listeners_created = h[:listeners_created]
+      h[:listener_states].each do |lsh|
+        @listener_states[lsh[:pid]] = ListenerState.new.tap do |ls|
+          ls.master_socket = lsh[:master_socket] && Socket.for_fd(lsh[:master_socket])
+          ls.options = lsh[:options]
+          ls.pid = lsh[:pid]
+          ls.worker_pids = lsh[:worker_pids]
+        end
+      end
+      @paused = h[:paused]
+      @pidfile = h[:pidfile]
+    end
+
+    # Public: Return this state so that it can be serialized.
+    def to_h
+      {
+        :config_paths => @config_paths,
+        :current_listener_pid => @current_listener_pid,
+        :exec_on_hup => @exec_on_hup,
+        :fast_exit => @fast_exit,
+        :last_good_listener_pid => @last_good_listener_pid,
+        :listeners_created => @listeners_created,
+        :listener_states => @listener_states.values.map { |ls| {
+          :master_socket => ls.master_socket && ls.master_socket.to_i,
+          :options => ls.options,
+          :pid => ls.pid,
+          :worker_pids => ls.worker_pids,
+        } },
+        :paused => @paused,
+        :pidfile => @pidfile,
+      }
+    end
+
+    # Public: Return an array of open sockets or other file handles that should be forwarded to a new master.
+    def sockets
+      @listener_states.values.map { |l| l.master_socket }.compact
+    end
+
     attr_reader :config_paths
     attr_accessor :current_listener_pid
     attr_reader :exec_on_hup

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -1,0 +1,19 @@
+module Resqued
+  class MasterState
+    def initialize(options)
+      @config_paths = options.fetch(:config_paths)
+      @fast_exit    = options.fetch(:fast_exit) { false }
+      @pidfile      = options.fetch(:master_pidfile) { nil }
+      @listeners_created = 0
+    end
+
+    attr_reader :config_paths
+    attr_accessor :current_listener
+    attr_reader :fast_exit
+    attr_accessor :last_good_listener
+    attr_accessor :listeners_created
+    attr_accessor :listener_pids
+    attr_accessor :paused
+    attr_reader :pidfile
+  end
+end

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -6,6 +6,7 @@ module Resqued
       @fast_exit    = options.fetch(:fast_exit) { false }
       @pidfile      = options.fetch(:master_pidfile) { nil }
       @listeners_created = 0
+      @listener_pids = {}
     end
 
     attr_reader :config_paths

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -36,20 +36,20 @@ module Resqued
     # Public: Return this state so that it can be serialized.
     def to_h
       {
-        :config_paths => @config_paths,
-        :current_listener_pid => @current_listener_pid,
-        :exec_on_hup => @exec_on_hup,
-        :fast_exit => @fast_exit,
-        :last_good_listener_pid => @last_good_listener_pid,
-        :listeners_created => @listeners_created,
-        :listener_states => @listener_states.values.map { |ls| {
-          :master_socket => ls.master_socket && ls.master_socket.to_i,
-          :options => ls.options,
-          :pid => ls.pid,
-          :worker_pids => ls.worker_pids,
+        config_paths: @config_paths,
+        current_listener_pid: @current_listener_pid,
+        exec_on_hup: @exec_on_hup,
+        fast_exit: @fast_exit,
+        last_good_listener_pid: @last_good_listener_pid,
+        listeners_created: @listeners_created,
+        listener_states: @listener_states.values.map { |ls| {
+          master_socket: ls.master_socket && ls.master_socket.to_i,
+          options: ls.options,
+          pid: ls.pid,
+          worker_pids: ls.worker_pids,
         } },
-        :paused => @paused,
-        :pidfile => @pidfile,
+        paused: @paused,
+        pidfile: @pidfile,
       }
     end
 

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -8,9 +8,9 @@ module Resqued
     # Public: When starting fresh, from command-line options, assign the initial values.
     def init(options)
       @config_paths = options.fetch(:config_paths)
-      @exec_on_hup  = options.fetch(:exec_on_hup) { false }
-      @fast_exit    = options.fetch(:fast_exit) { false }
-      @pidfile      = options.fetch(:master_pidfile) { nil }
+      @exec_on_hup  = options.fetch(:exec_on_hup, false)
+      @fast_exit    = options.fetch(:fast_exit, false)
+      @pidfile      = options.fetch(:master_pidfile, nil)
     end
 
     # Public: Restore state from a serialized form.

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -6,7 +6,7 @@ module Resqued
       @fast_exit    = options.fetch(:fast_exit) { false }
       @pidfile      = options.fetch(:master_pidfile) { nil }
       @listeners_created = 0
-      @listener_pids = {}
+      @listener_states = {}
     end
 
     attr_reader :config_paths
@@ -15,7 +15,7 @@ module Resqued
     attr_reader :fast_exit
     attr_accessor :last_good_listener_pid
     attr_accessor :listeners_created
-    attr_accessor :listener_pids
+    attr_reader :listener_states
     attr_accessor :paused
     attr_reader :pidfile
   end

--- a/lib/resqued/master_state.rb
+++ b/lib/resqued/master_state.rb
@@ -10,10 +10,10 @@ module Resqued
     end
 
     attr_reader :config_paths
-    attr_accessor :current_listener
+    attr_accessor :current_listener_pid
     attr_reader :exec_on_hup
     attr_reader :fast_exit
-    attr_accessor :last_good_listener
+    attr_accessor :last_good_listener_pid
     attr_accessor :listeners_created
     attr_accessor :listener_pids
     attr_accessor :paused

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.bindir  = 'exe'
   s.executables = %w(
     resqued
-    resqued-listener
   )
   s.add_dependency 'kgio', '~> 2.6'
   s.add_dependency 'resque', '>= 1.9.1'

--- a/spec/test_restart.sh
+++ b/spec/test_restart.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -e
+set -o nounset
+
+WORKDIR="$(mktemp)"
+PIDFILE="${WORKDIR}/resqued.pid"
+CONFIG="${WORKDIR}/config.rb"
+
+# mktemp makes a file, but we want a dir.
+rm -f "$WORKDIR"
+mkdir "$WORKDIR"
+
+set -x
+cd "$(dirname "$0")/.."
+
+main() {
+  trap cleanup EXIT
+
+  configure_resqued
+  start_resqued
+  restart_resqued
+  stop_resqued
+}
+
+configure_resqued() {
+  # Don't configure any workers. That way, we don't need to have redis running.
+  touch "${CONFIG}"
+}
+
+start_resqued() {
+  bin_resqued=bin/resqued
+  if [ -x gemfiles/bin/resqued ]; then
+    bin_resqued=gemfiles/bin/resqued
+  fi
+  $bin_resqued --pidfile "${PIDFILE}" "${CONFIG}" &
+  sleep 1
+  echo expect to find the master process and the first listener
+  running # set -e will make the test fail if it's not running
+  ps axo pid,args -H | grep [r]esqued-
+  ps axo pid,args | grep [r]esqued- | grep -q 'listener #1.*running'
+}
+
+restart_resqued() {
+  local pid="$(cat "${PIDFILE}")"
+  kill -HUP "$pid"
+  sleep 1
+  echo expect to find the master process and the second listener
+  running
+  ps axo pid,args -H | grep [r]esqued-
+  ps axo pid,args | grep [r]esqued- | grep -qv 'listener #1'
+  ps axo pid,args | grep [r]esqued- | grep -q 'listener #2.*running'
+}
+
+stop_resqued() {
+  local pid="$(cat "${PIDFILE}")"
+  kill -TERM "$pid"
+  sleep 1
+  echo expect everything to be stopped
+  if running >&/dev/null; then
+    echo "expected resqued to be stopped"
+    false
+  fi
+  ps axo pid,args -H | grep [r]esqued- || true
+  test -z "$(ps axo pid,args | grep [r]esqued-)"
+}
+
+running() {
+  set -e
+  test -f "${PIDFILE}"
+  local pid="$(cat "${PIDFILE}")"
+  kill -0 "$pid"
+  ps o pid,args "$pid"
+}
+
+cleanup() {
+  while running >&/dev/null; do
+    kill -TERM "$(cat "${PIDFILE}")"
+    sleep 2
+  done
+  rm -rfv "${WORKDIR}" || rm -rf "${WORKDIR}"
+}
+
+main


### PR DESCRIPTION
Resqued sometimes takes on changes that require the master process to be restarted. It'd be nice for this to happen automatically.

This PR makes it so that the master process will re-exec itself on SIGHUP. The old version serializes its state and passes it to the new version. Re-execing will make it so the master is running updated code. After the re-exec, it spawns a new listener. In most cases, this should be safe and allow us to update resqued in our production environment without manually recycling resqued-master processes on all of our hosts. Notably, this is not particularly safe if the new master is not able to start and replace the current one. This could happen if resqued itself is not able to boot, or if resqued is downgraded to 0.9.0 or earlier. Re-exec can be disabled by passing `--no-exec-on-hup` when starting resqued.

Another option would be to merge the master and listener process into a new master, and have the new master spawn a replacement. This would require some rework of how listeners communicate to the master about their running processes. It would also require our infra to change from simple process management to pidfile-based process management. Neither of these is prohibitive, but I opted not to do it this way because I'd rather not have to change our process monitors at this time.