### PR TITLE
Change shutdown signal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.bundle
+.git
+.*.swp
+bin
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,22 +12,24 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 29
+  Max: 29 # default is 15!
 
 Metrics/BlockLength:
-  Max: 144
+  Max: 32 # default is 25!
+  Exclude:
+    - "spec/**/*"
 
 Metrics/ClassLength:
-  Max: 198
+  Max: 201 # default is 100!
 
 Metrics/CyclomaticComplexity:
-  Max: 11
+  Max: 11 # default is 6!
 
 Metrics/MethodLength:
-  Max: 34
+  Max: 34 # default is 10!
 
 Metrics/PerceivedComplexity:
-  Max: 9
+  Max: 9 # default is 7!
 
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - "2.4"
   - "2.5"
   - "2.6"
+  - "2.7"
 bundler_args: "--binstubs bin"
 gemfile:
   - gemfiles/resque-min

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG RUBY_VERSION=2.7.1
+FROM ruby:${RUBY_VERSION}
+
+WORKDIR /resqued
+COPY . .
+RUN bundle install && \
+  bundle binstubs resqued
+
+CMD [ "bundle", "exec", "rake" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+

--- a/example/sleepy.rb
+++ b/example/sleepy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Push a job:
 #   bundle exec ruby example/sleepy.rb
 # Work queued jobs:
@@ -10,7 +12,7 @@ if $0 == __FILE__
   port = ENV["REDIS_PORT"] || 6379
   Resque.redis = Redis.new(host: host, port: port)
   puts "Pushing a #{QUEUE} job!"
-  Resque.push(QUEUE, class: "SleepyJob", :args => [])
+  Resque.push(QUEUE, class: "SleepyJob", args: [])
   exit 0
 end
 

--- a/example/sleepy.rb
+++ b/example/sleepy.rb
@@ -1,0 +1,27 @@
+# Push a job:
+#   bundle exec ruby example/sleepy.rb
+# Work queued jobs:
+#   bundle exec resqued example/sleepy.rb
+QUEUE = "sleepy-queue"
+
+if $0 == __FILE__
+  require "resque"
+  host = ENV["REDIS_HOST"] || "localhost"
+  port = ENV["REDIS_PORT"] || 6379
+  Resque.redis = Redis.new(host: host, port: port)
+  puts "Pushing a #{QUEUE} job!"
+  Resque.push(QUEUE, class: "SleepyJob", :args => [])
+  exit 0
+end
+
+before_fork do
+  host = ENV["REDIS_HOST"] || "localhost"
+  port = ENV["REDIS_PORT"] || 6379
+  Resque.redis = Redis.new(host: host, port: port)
+end
+
+after_fork do
+  require_relative "./sleepy_job"
+end
+
+worker QUEUE

--- a/example/sleepy_job.rb
+++ b/example/sleepy_job.rb
@@ -1,0 +1,7 @@
+class SleepyJob
+  def self.perform
+    puts "#{object_id} START sleep 30"
+    sleep 30
+    puts "#{object_id} STOP sleep 30"
+  end
+end

--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -120,9 +120,15 @@ module Resqued
       loop do
         check_for_expired_workers
         write_procline("shutdown")
-        SIGNAL_QUEUE.clear
 
         break if :no_child == reap_workers(Process::WNOHANG)
+
+        while updated_signal = SIGNAL_QUEUE.shift
+          case updated_signal
+          when :INT, :TERM, :QUIT
+            signal = updated_signal
+          end
+        end
 
         kill_all(signal)
 

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kgio", "~> 2.6"
   s.add_dependency "mono_logger", "~> 1.0"
   s.add_dependency "resque", ">= 1.9.1"
-  s.add_development_dependency "rake", "~> 0.9.0"
-  s.add_development_dependency "rspec", "~> 2.0", "< 2.99"
+  s.add_development_dependency "rake", "0.9.6"
+  s.add_development_dependency "rspec", "2.14.1"
   s.add_development_dependency "rubocop", "0.78.0"
 end

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency "mono_logger", "~> 1.0"
   s.add_dependency "resque", ">= 1.9.1"
   s.add_development_dependency "rake", "0.9.6"
-  s.add_development_dependency "rspec", "2.14.1"
+  s.add_development_dependency "rspec", "3.9.0"
   s.add_development_dependency "rubocop", "0.78.0"
 end

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kgio", "~> 2.6"
   s.add_dependency "mono_logger", "~> 1.0"
   s.add_dependency "resque", ">= 1.9.1"
-  s.add_development_dependency "rake", "0.9.6"
+  s.add_development_dependency "rake", "13.0.1"
   s.add_development_dependency "rspec", "3.9.0"
   s.add_development_dependency "rubocop", "0.78.0"
 end

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+docker-compose build --force-rm
+exec docker-compose run --rm test

--- a/spec/resqued/backoff_spec.rb
+++ b/spec/resqued/backoff_spec.rb
@@ -6,7 +6,7 @@ describe Resqued::Backoff do
   let(:backoff) { described_class.new(min: 0.5, max: 64.0) }
 
   it "can start on the first try" do
-    expect(backoff.wait?).to be_false
+    expect(backoff.wait?).to be_falsey
   end
 
   it "has no waiting at first" do
@@ -15,42 +15,42 @@ describe Resqued::Backoff do
 
   context "after expected exits" do
     before { 3.times { backoff.started } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(0.5) }
   end
 
   context "after one quick exit" do
     before { 1.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(1.0) }
   end
 
   context "after two quick starts" do
     before { 2.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(2.0) }
   end
 
   context "after five quick starts" do
     before { 6.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(32.0) }
   end
 
   context "after six quick starts" do
     before { 7.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(64.0) }
   end
 
   context "does not wait longer than 64s" do
     before { 8.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(64.0) }
     it "and resets after an expected exit" do
       backoff.started
       backoff.started
-      expect(backoff.wait?).to be_true
+      expect(backoff.wait?).to be true
       expect(backoff.how_long?).to be_close_to(0.5)
     end
   end

--- a/spec/resqued/test_case_spec.rb
+++ b/spec/resqued/test_case_spec.rb
@@ -7,8 +7,8 @@ describe Resqued::TestCase do
   context "LoadConfig" do
     let(:the_module) { described_class::LoadConfig }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_clean.rb"              }.not_to raise_error }
-    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_before_fork_raises.rb" }.to     raise_error }
-    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_after_fork_raises.rb"  }.to     raise_error }
+    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_before_fork_raises.rb" }.to     raise_error(RuntimeError) }
+    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_after_fork_raises.rb"  }.to     raise_error(RuntimeError) }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_no_workers.rb"         }.not_to raise_error }
   end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -11,6 +11,10 @@ module CustomMatchers
       @epsilon = 0.01
     end
 
+    def supports_block_expectations?
+      true
+    end
+
     def within(epsilon)
       @epsilon = epsilon
       self
@@ -24,8 +28,12 @@ module CustomMatchers
       @epsilon >= diff
     end
 
-    def failure_message_for_should
+    def failure_message
       "Expected block to run for #{@expected_duration} +/-#{@epsilon} seconds, but it ran for #{@actual_duration} seconds."
+    end
+
+    def failure_message_when_negated
+      "Expected block not to run for #{@expected_duration} +/-#{@epsilon} seconds, but it ran for #{@actual_duration} seconds."
     end
   end
 end


### PR DESCRIPTION
Resqued only uses the first shutdown signal (INT, TERM, QUIT) that it receives. This can be a problem if you wanted to have a process monitoring tool shut it down gracefully at first (QUIT) and more forcefully after some amount of time (TERM).

This pull request changes the shutdown handler so that it passes along new shutdown signals when they're received. This should make something like the following work as it looks like it should:

```bash
kill -QUIT $RESQUED_PID
for n in $(seq 1 30); do
  kill -0 $RESQUED_PID || exit 0 # it exited
  sleep 1
done
kill -TERM $RESQUED_PID
```