### PR TITLE
Update dev deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.bundle
+.git
+.*.swp
+bin
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - "2.4"
   - "2.5"
   - "2.6"
+  - "2.7"
 bundler_args: "--binstubs bin"
 gemfile:
   - gemfiles/resque-min

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG RUBY_VERSION=2.7.1
+FROM ruby:${RUBY_VERSION}
+
+WORKDIR /resqued
+COPY . .
+RUN bundle install && \
+  bundle binstubs resqued
+
+CMD [ "bundle", "exec", "rake" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kgio", "~> 2.6"
   s.add_dependency "mono_logger", "~> 1.0"
   s.add_dependency "resque", ">= 1.9.1"
-  s.add_development_dependency "rake", "~> 0.9.0"
-  s.add_development_dependency "rspec", "~> 2.0", "< 2.99"
+  s.add_development_dependency "rake", "0.9.6"
+  s.add_development_dependency "rspec", "2.14.1"
   s.add_development_dependency "rubocop", "0.78.0"
 end

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency "mono_logger", "~> 1.0"
   s.add_dependency "resque", ">= 1.9.1"
   s.add_development_dependency "rake", "0.9.6"
-  s.add_development_dependency "rspec", "2.14.1"
+  s.add_development_dependency "rspec", "3.9.0"
   s.add_development_dependency "rubocop", "0.78.0"
 end

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency "kgio", "~> 2.6"
   s.add_dependency "mono_logger", "~> 1.0"
   s.add_dependency "resque", ">= 1.9.1"
-  s.add_development_dependency "rake", "0.9.6"
+  s.add_development_dependency "rake", "13.0.1"
   s.add_development_dependency "rspec", "3.9.0"
   s.add_development_dependency "rubocop", "0.78.0"
 end

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+docker-compose build --force-rm
+exec docker-compose run --rm test

--- a/script/ci
+++ b/script/ci
@@ -1,6 +1,20 @@
 #!/bin/bash
 
 set -e
+set -o nounset
 
-docker-compose build --force-rm
+dcarg=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ruby)
+      dcarg="$dcarg --build-arg RUBY_VERSION=$2"
+      shift; shift;;
+    *)
+      echo 'Usage: script/ci [--ruby VERSION]'
+      exit 1
+      ;;
+  esac
+done
+
+docker-compose build --force-rm $dcarg
 exec docker-compose run --rm test

--- a/spec/resqued/backoff_spec.rb
+++ b/spec/resqued/backoff_spec.rb
@@ -6,7 +6,7 @@ describe Resqued::Backoff do
   let(:backoff) { described_class.new(min: 0.5, max: 64.0) }
 
   it "can start on the first try" do
-    expect(backoff.wait?).to be_false
+    expect(backoff.wait?).to be_falsey
   end
 
   it "has no waiting at first" do
@@ -15,42 +15,42 @@ describe Resqued::Backoff do
 
   context "after expected exits" do
     before { 3.times { backoff.started } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(0.5) }
   end
 
   context "after one quick exit" do
     before { 1.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(1.0) }
   end
 
   context "after two quick starts" do
     before { 2.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(2.0) }
   end
 
   context "after five quick starts" do
     before { 6.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(32.0) }
   end
 
   context "after six quick starts" do
     before { 7.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(64.0) }
   end
 
   context "does not wait longer than 64s" do
     before { 8.times { backoff.started; backoff.died } }
-    it { expect(backoff.wait?).to be_true }
+    it { expect(backoff.wait?).to be true }
     it { expect(backoff.how_long?).to be_close_to(64.0) }
     it "and resets after an expected exit" do
       backoff.started
       backoff.started
-      expect(backoff.wait?).to be_true
+      expect(backoff.wait?).to be true
       expect(backoff.how_long?).to be_close_to(0.5)
     end
   end

--- a/spec/resqued/test_case_spec.rb
+++ b/spec/resqued/test_case_spec.rb
@@ -7,8 +7,8 @@ describe Resqued::TestCase do
   context "LoadConfig" do
     let(:the_module) { described_class::LoadConfig }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_clean.rb"              }.not_to raise_error }
-    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_before_fork_raises.rb" }.to     raise_error }
-    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_after_fork_raises.rb"  }.to     raise_error }
+    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_before_fork_raises.rb" }.to     raise_error(RuntimeError) }
+    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_after_fork_raises.rb"  }.to     raise_error(RuntimeError) }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_no_workers.rb"         }.not_to raise_error }
   end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -11,6 +11,10 @@ module CustomMatchers
       @epsilon = 0.01
     end
 
+    def supports_block_expectations?
+      true
+    end
+
     def within(epsilon)
       @epsilon = epsilon
       self
@@ -24,8 +28,12 @@ module CustomMatchers
       @epsilon >= diff
     end
 
-    def failure_message_for_should
+    def failure_message
       "Expected block to run for #{@expected_duration} +/-#{@epsilon} seconds, but it ran for #{@actual_duration} seconds."
+    end
+
+    def failure_message_when_negated
+      "Expected block not to run for #{@expected_duration} +/-#{@epsilon} seconds, but it ran for #{@actual_duration} seconds."
     end
   end
 end


### PR DESCRIPTION
This avoids vulnerabilities and deprecation warnings from earlier versions of rspec and rake. I also added `script/ci [--ruby VERSION]` to let me run something like what travis does, except locally, so that i get faster cycle time on changes like this.