### PR TITLE
Use at least one worker when percent is specified

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,9 @@ Metrics/AbcSize:
   Max: 29
 
 Metrics/BlockLength:
-  Max: 144
+  Max: 32
+  ExcludedMethods:
+    - describe
 
 Metrics/ClassLength:
   Max: 198

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 Starting with version 0.6.1, resqued uses semantic versioning to indicate incompatibilities between the master process, listener process, and configuration.
 
+v0.10.1
+-------
+* When using 'percent' for a queue in a worker pool, always assign at least one worker. (#57)
+
 v0.10.0
 -------
 * Master process restarts itself (#51), so that it doesn't continue running stale code indefinitely. This will help with the rollout process when changes like #50 are introduced, so that the master process will catch up. The risk of this is that the master process might not be able to be restarted, which would lead to it crashing. The mostly likely way for that to happen is if you try to roll back your version of resqued to 0.9.0 or earlier. If you need to do that, ensure that your process monitor (systemd, god, etc.) is able to restart the master process. You can disable the new behavior by passing `--no-exec-on-hup`.

--- a/lib/resqued/config/worker.rb
+++ b/lib/resqued/config/worker.rb
@@ -112,7 +112,7 @@ module Resqued
         elsif value.is_a?(1.class)
           value < @pool_size ? value : @pool_size
         elsif value.is_a?(Float) && value >= 0.0 && value <= 1.0
-          (@pool_size * value).to_i
+          [(@pool_size * value).to_i, 1].max
         else
           raise TypeError, "Unknown concurrency value: #{value.inspect}"
         end

--- a/spec/resqued/config/worker_spec.rb
+++ b/spec/resqued/config/worker_spec.rb
@@ -55,6 +55,17 @@ describe Resqued::Config::Worker do
     end
   end
 
+  context "small pool with percent" do
+    let(:config) { <<-END_CONFIG }
+      worker_pool 2
+      queue "a"
+      queue "b", :percent => 45
+    END_CONFIG
+    it { expect(result.size).to eq(2) }
+    it { expect(result[0]).to eq(queues: ["a", "b"]) }
+    it { expect(result[1]).to eq(queues: ["a"]) }
+  end
+
   context "pool (hash for concurrency)" do
     let(:config) { <<-END_CONFIG }
       before_fork { }


### PR DESCRIPTION
Given this config:

```ruby
worker_count = (ENV["RESQUE_WORKERS"] || 10).to_i
worker_pool worker_count
queue "a"
queue "b", percent: 45
```

We'll get four workers for queue "b" by default. But if `RESQUE_WORKERS` is set to 1 or 2, integer division gives us 0 workers. That is unlikely to match the intent of the config author. This PR changes the config code to ensure that every queue specified like this will get at least one worker.