### PR TITLE
Don't hang on a dead socket

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -85,6 +85,8 @@ module Resqued
 
       write_procline("shutdown")
       burn_down_workers(exit_signal || :QUIT)
+      @socket.close
+      @socket = nil
     end
 
     # Private.

--- a/lib/resqued/listener_proxy.rb
+++ b/lib/resqued/listener_proxy.rb
@@ -99,7 +99,10 @@ module Resqued
     def worker_finished(pid)
       return if @state.master_socket.nil?
 
-      @state.master_socket.puts(pid)
+      @state.master_socket.write_nonblock("#{pid}\n")
+    rescue IO::WaitWritable
+      log "Couldn't tell #{@state.pid} that #{pid} exited!"
+      # Ignore it, maybe the next time it'll work.
     rescue Errno::EPIPE
       @state.master_socket.close
       @state.master_socket = nil


### PR DESCRIPTION
In prod, we've seen some listener processes get stuck after they have shut down but before the process exits. The master continues trying to send messages to the listener, though, and the pipe eventually fills up and blocks the master. This results in an unresponsive master, too. I can reproduce the problem on my mac by running `resqued bad.rb` with this content in `bad.rb`, and `kill -HUP` the master 15x.

```
# bad.rb
class FakeWorker
  def work(*)
    trap(:QUIT) { exit! }
    sleep 100000000
  end
end

worker_factory { |queues| FakeWorker.new }
before_fork { at_exit { sleep 1000000000 } }

worker_pool 100
queue "*"
```

This branch changes the listener so that it closes the pipe that it shares with the master after it has finished its shutdown sequence. This branch also changes the master to use a non-blocking write to the listener. Either of these changes can prevent the master from becoming unresponsive even if a listener hangs after it finishes its `#run`.

cc @zerowidth @BenEddy 