### PR TITLE
Ignore SIGHUP in Listener and Worker processes

### DIFF
--- a/docs/signals.md
+++ b/docs/signals.md
@@ -34,6 +34,8 @@ The Listener process forwards `SIGCONT` to all of its workers.
 
 The Listener process handles `SIGINT`, `SIGTERM`, and `SIGQUIT`. When it receives one of these signals, it goes into shutdown mode. It sends the received signal to all of its workers. When all workers have exited, the Listener process exits.
 
+The Listener process handles `SIGHUP` and does nothing. This makes it easier to reload resqued in a docker container, since many container platforms will send a requested signal to all processes in the container.
+
 ## Worker
 
 The Worker process uses resque's signal handling. Resque 1.23.0 handles the following signals:
@@ -44,3 +46,5 @@ The Worker process uses resque's signal handling. Resque 1.23.0 handles the foll
 * `USR1`: Kill the forked child immediately, continue processing jobs.
 * `USR2`: Don't process any new jobs
 * `CONT`: Start processing jobs again after a USR2
+
+Resqued leaves a handler for `HUP` in place that does nothing. This makes it easier to reload resqued in a docker container, since many container platforms will send a requested signal to all processes in the container.

--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -69,7 +69,7 @@ module Resqued
 
     # Public: Run the main loop.
     def run
-      trap(:HUP) { } # ignore this, in case it trickles in from the master.
+      trap(:HUP) {} # ignore this, in case it trickles in from the master.
       trap(:CHLD) { awake }
       SIGNALS.each { |signal| trap(signal) { SIGNAL_QUEUE << signal; awake } }
       @socket.close_on_exec = true

--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -63,12 +63,13 @@ module Resqued
     end
 
     SIGNALS = [:CONT, :QUIT, :INT, :TERM].freeze
-    ALL_SIGNALS = SIGNALS + [:CHLD]
+    ALL_SIGNALS = SIGNALS + [:CHLD, :HUP]
 
     SIGNAL_QUEUE = [] # rubocop: disable Style/MutableConstant
 
     # Public: Run the main loop.
     def run
+      trap(:HUP) { } # ignore this, in case it trickles in from the master.
       trap(:CHLD) { awake }
       SIGNALS.each { |signal| trap(signal) { SIGNAL_QUEUE << signal; awake } }
       @socket.close_on_exec = true

--- a/lib/resqued/version.rb
+++ b/lib/resqued/version.rb
@@ -1,3 +1,3 @@
 module Resqued
-  VERSION = '0.10.3'
+  VERSION = "0.10.3".freeze
 end

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -92,7 +92,7 @@ module Resqued
         # In case we get a signal before resque is ready for it.
         Resqued::Listener::ALL_SIGNALS.each { |signal| trap(signal, "DEFAULT") }
         # Continue ignoring SIGHUP, though.
-        trap(:HUP) { }
+        trap(:HUP) {}
         # If we get a QUIT during boot, just spin back down.
         trap(:QUIT) { exit! 0 }
 

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -91,7 +91,11 @@ module Resqued
       else
         # In case we get a signal before resque is ready for it.
         Resqued::Listener::ALL_SIGNALS.each { |signal| trap(signal, "DEFAULT") }
-        trap(:QUIT) { exit! 0 } # If we get a QUIT during boot, just spin back down.
+        # Continue ignoring SIGHUP, though.
+        trap(:HUP) { }
+        # If we get a QUIT during boot, just spin back down.
+        trap(:QUIT) { exit! 0 }
+
         $0 = "STARTING RESQUE FOR #{queues.join(',')}"
         resque_worker = @worker_factory.call(queues)
         @config.after_fork(resque_worker)

--- a/script/release
+++ b/script/release
@@ -86,7 +86,7 @@ run() {
 set_gem_version() {
   cat >lib/resqued/version.rb <<V
 module Resqued
-  VERSION = '${version}'
+  VERSION = "${version}".freeze
 end
 V
 }

--- a/spec/integration/listener_still_starting_spec.rb
+++ b/spec/integration/listener_still_starting_spec.rb
@@ -11,6 +11,7 @@ describe "Listener still starting on SIGHUP" do
     CONFIG
     expect_running listener: "listener #1"
     restart_resqued
+    sleep 2
     expect_running listener: "listener #2"
   end
 

--- a/spec/resqued/config/worker_spec.rb
+++ b/spec/resqued/config/worker_spec.rb
@@ -125,17 +125,17 @@ describe Resqued::Config::Worker do
 
   context "pool, with shuffled queues" do
     let(:config) { <<-END_CONFIG }
-      worker_pool 20, :shuffle_queues => true
-      queue 'a', :count => 10
-      queue 'b', :count => 15
+      worker_pool 200, :shuffle_queues => true
+      queue 'a', :count => 100
+      queue 'b', :count => 150
     END_CONFIG
-    it { expect(result.size).to eq(20) }
-    it { (0..9).each { |i| expect(result[i][:queues].sort).to eq(["a", "b"]) } }
-    it { (10..14).each { |i| expect(result[i][:queues]).to eq(["b"]) } }
-    it { (15..19).each { |i| expect(result[i][:queues]).to eq(["*"]) } }
+    it { expect(result.size).to eq(200) }
+    it { (0..99).each { |i| expect(result[i][:queues].sort).to eq(["a", "b"]) } }
+    it { (100..149).each { |i| expect(result[i][:queues]).to eq(["b"]) } }
+    it { (150..199).each { |i| expect(result[i][:queues]).to eq(["*"]) } }
     it { result.each { |x| expect(x).not_to have_key(:shuffle_queues) } }
     it do
-      shuffled_queues = result.take(10).map { |x| x[:queues] }
+      shuffled_queues = result.take(100).map { |x| x[:queues] }
       expect(shuffled_queues.sort.uniq).to eq([["a", "b"], ["b", "a"]]) # Some of the queues should be shuffled
     end
   end


### PR DESCRIPTION
Container environments tend to pass signals to all of the processes in a container. So, if you are running resqued in a container and want to reload it with a SIGHUP, you'd end up sending SIGHUP to the master and the listener and workers. The master process would handle it gracefully, as expected, but the others would exit abruptly.

This PR sets the listener and workers up to ignore SIGHUP. Note: This is the first signal handler that resqued installs and leaves in place in resque worker processes. It's appropriate in this instance because resqued changes the environment of resque from it being the top-level process in a hierarchy to being a component of a larger pool of processes, so it makes sense for it to behave differently. In other words, with a resqued pool, we'd expect the entire set of processes to reload gracefully on SIGHUP, which is different from a single resque worker, which doesn't make any guarantees about what it does on SIGHUP.

cc @ipmsteven
