### PR TITLE
Guard against @socket.nil? in one more place

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -86,7 +86,7 @@ module Resqued
 
       write_procline("shutdown")
       burn_down_workers(exit_signal || :QUIT)
-      @socket.close
+      @socket&.close
       @socket = nil
     end
 


### PR DESCRIPTION
We ran into an issue in production when using `resqued --fast-exit`. During shutdown, resqued's listener crashes right before it exits normally.

```
NoMethodError: undefined method `close' for nil:NilClass
  vendor/gems/2.7.1/ruby/2.7.0/gems/resqued-0.10.3/lib/resqued/listener.rb:88:in `run'
  vendor/gems/2.7.1/ruby/2.7.0/gems/resqued-0.10.3/lib/resqued/listener.rb:62:in `exec!'
  vendor/gems/2.7.1/ruby/2.7.0/gems/resqued-0.10.3/exe/resqued:5:in `<top (required)>'
```

This isn't a huge problem, since this is happening at the very end of shutting down the process, but it's noisy in our exception tracker.

Related changes:
- #45 added `--fast-exit`, which can result in `@socket` getting set to `nil`.
- #58 added `@socket.close` during shutdown, but didn't check it for `nil`.

cc @steves