### PR TITLE
Do not require resque in the resqued gem

### DIFF
--- a/lib/resqued/listener.rb
+++ b/lib/resqued/listener.rb
@@ -96,6 +96,8 @@ module Resqued
       if Resque.respond_to?("logger=")
         Resque.logger = Resqued::Logging.build_logger
       end
+    rescue LoadError
+      # Skip this step.
     end
 
     # Private.

--- a/lib/resqued/test_case.rb
+++ b/lib/resqued/test_case.rb
@@ -17,7 +17,6 @@ module Resqued
         config = Resqued::Config.new(paths)
         config.before_fork(RuntimeInfo.new)
         config.build_workers
-        config.after_fork(Resque::Worker.new("*"))
       end
     end
 

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -1,4 +1,3 @@
-require "resque"
 require "digest"
 
 require "resqued/backoff"
@@ -10,6 +9,7 @@ module Resqued
     include Resqued::Logging
 
     DEFAULT_WORKER_FACTORY = lambda { |queues|
+      require "resque"
       resque_worker = Resque::Worker.new(*queues)
       resque_worker.term_child = true if resque_worker.respond_to?("term_child=")
       redis_client = Resque.redis.respond_to?(:_client) ? Resque.redis._client : Resque.redis.client

--- a/resqued.gemspec
+++ b/resqued.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   ]
   s.add_dependency "kgio", "~> 2.6"
   s.add_dependency "mono_logger", "~> 1.0"
-  s.add_dependency "resque", ">= 1.9.1"
+  s.add_development_dependency "resque", ">= 1.9.1"
   s.add_development_dependency "rake", "13.0.1"
   s.add_development_dependency "rspec", "3.9.0"
   s.add_development_dependency "rubocop", "0.78.0"


### PR DESCRIPTION
It's possible to use resqued with other job systems than `resque` by providing a `worker_factory` in config. In that case, it's impolite of resqued to pull resque in as a dependency.