### PR TITLE
Add a preStop lifecycle hook for kubernetes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,10 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
+Naming/FileName:
+  Exclude:
+    - lib/resqued/quit-and-wait.rb
+
 Style/AndOr:
   EnforcedStyle: conditionals
 

--- a/exe/resqued
+++ b/exe/resqued
@@ -1,8 +1,13 @@
 #!/usr/bin/env ruby
 
-if ARGV[0] == "listener"
+case ARGV[0]
+when "listener"
   require "resqued/listener"
   Resqued::Listener.exec!
+  exit 0
+when "quit-and-wait"
+  require "resqued/quit-and-wait"
+  Resqued::QuitAndWait.exec!(ARGV.drop(1))
   exit 0
 end
 

--- a/lib/resqued/quit-and-wait.rb
+++ b/lib/resqued/quit-and-wait.rb
@@ -3,7 +3,7 @@ require "optparse"
 module Resqued
   class QuitAndWait
     def self.exec!(argv)
-      grace_seconds = 30
+      options = {grace_seconds: 30}
 
       opts = OptionParser.new do |opts|
         opts.banner = <<USAGE
@@ -27,8 +27,7 @@ USAGE
         end
 
         opts.on "--grace-period SECONDS", Numeric, "If resqued does not exit within SECONDS (default 15) seconds, exit with an error" do |v|
-          grace_period = v
-          grace_second = v
+          options[:grace_seconds] = v
         end
       end
 
@@ -37,9 +36,9 @@ USAGE
         puts opts
         exit 1
       end
-      pidfile = argv.shift
+      options[:pidfile] = argv.shift
 
-      new(grace_seconds: grace_seconds, pidfile: pidfile).exec!
+      new(**options).exec!
     end
 
     def initialize(grace_seconds:, pidfile:)

--- a/lib/resqued/quit-and-wait.rb
+++ b/lib/resqued/quit-and-wait.rb
@@ -29,6 +29,10 @@ USAGE
         opts.on "--grace-period SECONDS", Numeric, "If resqued does not exit within SECONDS (default 15) seconds, exit with an error" do |v|
           options[:grace_seconds] = v
         end
+
+        opts.on "--quiet" do
+          options[:quiet] = true
+        end
       end
 
       argv = opts.parse(argv)
@@ -41,12 +45,13 @@ USAGE
       new(**options).exec!
     end
 
-    def initialize(grace_seconds:, pidfile:)
+    def initialize(grace_seconds:, pidfile:, quiet: false)
       @grace_seconds = grace_seconds
       @pidfile = pidfile
+      @quiet = quiet
     end
 
-    attr_reader :grace_seconds, :pidfile
+    attr_reader :grace_seconds, :pidfile, :quiet
 
     def exec!
       start = Time.now
@@ -71,6 +76,7 @@ USAGE
     end
 
     def log(message)
+      return if quiet
       puts "#{Time.now.strftime("%H:%M:%S.%L")} #{message}"
     end
   end

--- a/lib/resqued/quit-and-wait.rb
+++ b/lib/resqued/quit-and-wait.rb
@@ -3,17 +3,17 @@ require "optparse"
 module Resqued
   class QuitAndWait
     def self.exec!(argv)
-      options = {grace_seconds: 30}
+      options = { grace_seconds: 30 }
 
-      opts = OptionParser.new do |opts|
-        opts.banner = <<USAGE
-Usage: resqued quit-and-wait PIDFILE [--grace-period SECONDS]
+      opts = OptionParser.new do |opts| # rubocop: disable Lint/ShadowingOuterLocalVariable
+        opts.banner = <<~USAGE
+          Usage: resqued quit-and-wait PIDFILE [--grace-period SECONDS]
 
-Use this as a preStop script in kubernetes. This script will send a SIGQUIT to
-resqued immediately, and then sleep until either resqued exits or until the
-grace period is nearing expiration. This script exits 0 if resqued exited and
-99 otherwise.
-USAGE
+          Use this as a preStop script in kubernetes. This script will send a SIGQUIT to
+          resqued immediately, and then sleep until either resqued exits or until the
+          grace period is nearing expiration. This script exits 0 if resqued exited and
+          99 otherwise.
+        USAGE
 
         opts.on "-h", "--help", "Show this message" do
           puts opts
@@ -77,7 +77,8 @@ USAGE
 
     def log(message)
       return if quiet
-      puts "#{Time.now.strftime("%H:%M:%S.%L")} #{message}"
+
+      puts "#{Time.now.strftime('%H:%M:%S.%L')} #{message}"
     end
   end
 end

--- a/lib/resqued/quit-and-wait.rb
+++ b/lib/resqued/quit-and-wait.rb
@@ -1,0 +1,78 @@
+require "optparse"
+
+module Resqued
+  class QuitAndWait
+    def self.exec!(argv)
+      grace_seconds = 30
+
+      opts = OptionParser.new do |opts|
+        opts.banner = <<USAGE
+Usage: resqued quit-and-wait PIDFILE [--grace-period SECONDS]
+
+Use this as a preStop script in kubernetes. This script will send a SIGQUIT to
+resqued immediately, and then sleep until either resqued exits or until the
+grace period is approximately 5 seconds from expiration. This script exits 0 if
+resqued exited and 99 otherwise.
+USAGE
+
+        opts.on "-h", "--help", "Show this message" do
+          puts opts
+          exit
+        end
+
+        opts.on "-v", "--version", "Show the version" do
+          require "resqued/version"
+          puts Resqued::VERSION
+          exit
+        end
+
+        opts.on "--grace-period SECONDS", Numeric, "If resqued does not exit within SECONDS (default 15) seconds, exit with an error" do |v|
+          grace_period = v
+          grace_second = v
+        end
+      end
+
+      argv = opts.parse(argv)
+      if argv.size != 1
+        puts opts
+        exit 1
+      end
+      pidfile = argv.shift
+
+      new(grace_seconds: grace_seconds, pidfile: pidfile).exec!
+    end
+
+    def initialize(grace_seconds:, pidfile:)
+      @grace_seconds = grace_seconds
+      @pidfile = pidfile
+    end
+
+    attr_reader :grace_seconds, :pidfile
+
+    def exec!
+      start = Time.now
+      stop_at = start + grace_seconds - 5
+      pid = File.read(pidfile).to_i
+
+      log "kill -QUIT #{pid} (resqued-master)"
+      Process.kill(:QUIT, pid)
+
+      while Time.now < stop_at
+        begin
+          # check if pid is still alive.
+          Process.kill(0, pid)
+        rescue Errno::ESRCH # no such process, it exited!
+          log "ok: resqued-master with pid #{pid} exited"
+          exit 0
+        end
+      end
+
+      log "giving up, resqued-master with pid #{pid} is still running."
+      exit 99
+    end
+
+    def log(message)
+      puts "#{Time.now.strftime("%H:%M:%S.%L")} #{message}"
+    end
+  end
+end

--- a/lib/resqued/quit-and-wait.rb
+++ b/lib/resqued/quit-and-wait.rb
@@ -11,8 +11,8 @@ Usage: resqued quit-and-wait PIDFILE [--grace-period SECONDS]
 
 Use this as a preStop script in kubernetes. This script will send a SIGQUIT to
 resqued immediately, and then sleep until either resqued exits or until the
-grace period is approximately 5 seconds from expiration. This script exits 0 if
-resqued exited and 99 otherwise.
+grace period is nearing expiration. This script exits 0 if resqued exited and
+99 otherwise.
 USAGE
 
         opts.on "-h", "--help", "Show this message" do
@@ -26,7 +26,7 @@ USAGE
           exit
         end
 
-        opts.on "--grace-period SECONDS", Numeric, "If resqued does not exit within SECONDS (default 15) seconds, exit with an error" do |v|
+        opts.on "--grace-period SECONDS", Numeric, "Grace period provided to container runtime (default 30)" do |v|
           options[:grace_seconds] = v
         end
 

--- a/spec/integration/quit_and_wait_spec.rb
+++ b/spec/integration/quit_and_wait_spec.rb
@@ -22,7 +22,7 @@ describe "quit-and-wait gracefully stops resqued" do
     end
 
     Timeout.timeout(15) do
-      expect(system resqued_path, "quit-and-wait", pidfile, "--grace-period", "10").to be true
+      expect(system(resqued_path, "quit-and-wait", pidfile, "--grace-period", "10")).to be true
     end
 
     expect_not_running

--- a/spec/integration/quit_and_wait_spec.rb
+++ b/spec/integration/quit_and_wait_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "timeout"
+
+describe "quit-and-wait gracefully stops resqued" do
+  include ResquedIntegrationHelpers
+
+  it do
+    pidfile = File.join(SPEC_TEMPDIR, "graceful.pid")
+
+    start_resqued(pidfile: pidfile)
+    expect_running listener: "listener #1"
+
+    # Make sure the process gets cleaned up.
+    Thread.new do
+      begin
+        loop do
+          Process.wait(@pid)
+        end
+      rescue Errno::ECHILD
+        # ok!
+      end
+    end
+
+    Timeout.timeout(15) do
+      expect(system resqued_path, "quit-and-wait", pidfile, "--grace-period", "10").to be true
+    end
+
+    expect_not_running
+  end
+
+  after do
+    begin
+      Process.kill(:QUIT, @pid) if @pid
+    rescue Errno::ESRCH
+    end
+  end
+end

--- a/spec/support/resqued_integration_helpers.rb
+++ b/spec/support/resqued_integration_helpers.rb
@@ -1,20 +1,25 @@
 module ResquedIntegrationHelpers
   include ResquedPath
 
-  def start_resqued(config: "", debug: false)
-    # Don't configure any workers. That way, we don't need to have redis running.
+  def start_resqued(config: "", debug: false, pidfile: nil)
+    # Don't configure any workers by default. That way, we don't need to have
+    # redis running.
     config_path = File.join(SPEC_TEMPDIR, "config.rb")
     File.write(config_path, config)
 
-    @pid =
-      if debug
-        spawn resqued_path, config_path
-      else
-        logfile = File.join(SPEC_TEMPDIR, "resqued.log")
-        File.write(logfile, "") # truncate it
+    cmd = [resqued_path]
+    if pidfile
+      cmd += ["--pidfile", pidfile]
+    end
+    unless debug
+      logfile = File.join(SPEC_TEMPDIR, "resqued.log")
+      File.write(logfile, "") # truncate it
+      cmd += ["--logfile", logfile]
+    end
+    cmd += [config_path]
 
-        spawn resqued_path, "--logfile", logfile, config_path
-      end
+    @pid = spawn(*cmd)
+
     sleep 1.0
   end
 


### PR DESCRIPTION
We're running resqued in kubernetes these days, and have had an ad hoc script in place to help manage shutdowns. This pull request adds a new subcommand to resqued, based on our ad hoc script.

Kubernetes sends the termination signal (SIGTERM) to all processes in a pod, which is not what resqued expects. The SIGTERM causes resque workers to exit without finishing their current work, which is normally not what we want. What we'd prefer is to have Kube send SIGQUIT to the top-level process (resqued master) so it can gracefully shut down the workers.

To use this:
1. Make sure that resqued is recording its pid.
2. Add this as a preStop script.

Example config fragment:

```yaml
  containers:
  - name: resqued
    command: ['bundle', 'exec', 'resqued', 'config/resqued.rb', '-p', 'resqued.pid']
    lifecycle:
      preStop:
        exec:
          command: ['bundle', 'exec', 'resqued', 'quit-and-wait', 'resqued.pid']
```