### PR TITLE
Add worker summary in `after_exit` listener hook for worker diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ You can configure the Resque worker in the `after_fork` block
       worker.term_timeout = 1.minute
     end
 
+    after_reap do |worker_summary|
+        puts "Worker was alive for #{worker_summary.alive_time_sec}"
+    end
+
 In this example, a Rails application is being set up with 7 workers:
 * high
 * low (interval = 30)

--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ You can configure the Resque worker in the `after_fork` block
       worker.term_timeout = 1.minute
     end
 
-    after_reap do |worker_summary|
+    after_exit do |worker_summary|
         puts "Worker was alive for #{worker_summary.alive_time_sec}"
+        puts "Process::Status of exited worker: #{worker_summary.process_status.inspect}"
     end
 
 In this example, a Rails application is being set up with 7 workers:

--- a/lib/resqued/config.rb
+++ b/lib/resqued/config.rb
@@ -1,5 +1,6 @@
 require "resqued/config/after_fork"
 require "resqued/config/before_fork"
+require "resqued/config/after_exit"
 require "resqued/config/worker"
 
 module Resqued
@@ -25,6 +26,11 @@ module Resqued
       # Public: Performs the `after_fork` action from the config.
       def after_fork(worker)
         Resqued::Config::AfterFork.new(worker: worker).apply_all(@config_data)
+      end
+
+      # Public: Perform the `after_exit` action from the config.
+      def after_exit(worker_summary)
+        Resqued::Config::AfterExit.new(worker_summary: worker_summary).apply_all(@config_data)
       end
 
       # Public: Builds the workers specified in the config.

--- a/lib/resqued/config/after_exit.rb
+++ b/lib/resqued/config/after_exit.rb
@@ -1,0 +1,22 @@
+require "resqued/config/base"
+
+module Resqued
+  module Config
+    # A config handler that executes the `after_exit` block.
+    #
+    #     after_exit do |worker_summary|
+    #       # Runs in each listener.
+    #     end
+    class AfterExit < Base
+      # Public.
+      def initialize(options = {})
+        @worker_summary = options.fetch(:worker_summary)
+      end
+
+      # DSL: execute the `after_exit` block.
+      def after_exit
+        yield @worker_summary
+      end
+    end
+  end
+end

--- a/lib/resqued/config/dsl.rb
+++ b/lib/resqued/config/dsl.rb
@@ -12,6 +12,10 @@ module Resqued
       def after_fork(&block)
       end
 
+      # Public: Define a block to be run once after each worker exits.
+      def after_exit(&block)
+      end
+
       # Public: Define a worker that will work on a queue.
       def worker(*queues)
       end

--- a/lib/resqued/test_case.rb
+++ b/lib/resqued/test_case.rb
@@ -18,7 +18,7 @@ module Resqued
         config.before_fork(RuntimeInfo.new)
         config.build_workers
         config.after_fork(FakeWorker.new)
-        config.after_exit(Resqued::WorkerSummary.new(1.0))
+        config.after_exit(Resqued::WorkerSummary.new(alive_time_sec: 1.0, process_status: Process::Status.allocate))
       end
     end
 

--- a/lib/resqued/test_case.rb
+++ b/lib/resqued/test_case.rb
@@ -18,6 +18,7 @@ module Resqued
         config.before_fork(RuntimeInfo.new)
         config.build_workers
         config.after_fork(FakeWorker.new)
+        config.after_exit(Resqued::WorkerSummary.new(1.0))
       end
     end
 

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -64,8 +64,8 @@ module Resqued
         @pid = nil
         @backoff.died unless @killed
       elsif !process_status.nil? && @self_started
-        alive_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
-        @config.after_exit(WorkerSummary.new(alive_time))
+        alive_time_sec = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
+        @config.after_exit(WorkerSummary.new(alive_time_sec: alive_time_sec, process_status: process_status))
 
         log :debug, "#{summary} I exited: #{process_status}"
         @pid = nil
@@ -121,12 +121,12 @@ module Resqued
 
   # Metadata for an exited listener worker.
   class WorkerSummary
-    def initialize(alive_time_sec)
-      @alive_time_sec = alive_time_sec
-    end
 
-    def alive_time_sec
-      @alive_time_sec
+    attr_reader :alive_time_sec, :process_status
+
+    def initialize(alive_time_sec: , process_status:)
+      @alive_time_sec = alive_time_sec
+      @process_status = process_status
     end
   end
 end

--- a/lib/resqued/worker.rb
+++ b/lib/resqued/worker.rb
@@ -122,7 +122,7 @@ module Resqued
   class WorkerSummary
     attr_reader :alive_time_sec, :process_status
 
-    def initialize(alive_time_sec: , process_status:)
+    def initialize(alive_time_sec:, process_status:)
       @alive_time_sec = alive_time_sec
       @process_status = process_status
     end

--- a/script/test-all-resques
+++ b/script/test-all-resques
@@ -19,6 +19,9 @@ end
 after_fork do
   File.open('$OUTPUT', 'a') { |f| f.puts Gem.loaded_specs['resque'].version.to_s }
 end
+after_exit do |worker_summary|
+  puts "#{worker_summary.alive_time_sec}"
+end
 worker 'example-queue'
 END_CONFIG
 

--- a/spec/fixtures/test_case_after_exit_raises.rb
+++ b/spec/fixtures/test_case_after_exit_raises.rb
@@ -1,0 +1,5 @@
+after_exit do
+  raise "boom"
+end
+
+worker "test"

--- a/spec/resqued/config/exit_event_spec.rb
+++ b/spec/resqued/config/exit_event_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+require "resqued/worker"
+require "resqued/config/after_exit"
+
+describe do
+  before { evaluator.apply(config) }
+
+  context "after_exit" do
+    # Run the after_exit block.
+    #
+    #    after_exit do |worker_summary|
+    #      puts "#{worker_summary.alive_time_sec}"
+    #    end
+    #
+    # ignore calls to any other top-level method.
+
+    let(:config) { <<-END_CONFIG }
+      worker('one')
+      worker_pool(1)
+      queue('*')
+
+      after_exit do |worker_summary|
+        $after_exit_called = true
+        $worker_alive_time_sec = worker_summary.alive_time_sec
+      end
+    END_CONFIG
+
+    let(:evaluator) { Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(1)) }
+
+    it { expect($after_exit_called).to eq(true) }
+    it { expect($worker_alive_time_sec > 0).to eq(true) }
+  end
+end
+
+class FakeResqueWorker
+  attr_accessor :token
+end

--- a/spec/resqued/config/exit_event_spec.rb
+++ b/spec/resqued/config/exit_event_spec.rb
@@ -27,7 +27,11 @@ describe do
     END_CONFIG
 
     let(:evaluator) {
-      fork { 0 }
+      # In ruby versions < 3, Process::Status evaluates $? regardless of what status is returned by
+      # exitcode for a status created with Process::Status.allocate
+      fork do
+        0
+      end
       status = Process.waitpid2[1]
       Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(alive_time_sec: 1, process_status: status))
     }

--- a/spec/resqued/config/exit_event_spec.rb
+++ b/spec/resqued/config/exit_event_spec.rb
@@ -30,7 +30,7 @@ describe do
       # In ruby versions < 3, Process::Status evaluates $? regardless of what status is returned by
       # exitcode for a status created with Process::Status.allocate
       fork do
-        0
+        exit!
       end
       status = Process.waitpid2[1]
       Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(alive_time_sec: 1, process_status: status))

--- a/spec/resqued/config/exit_event_spec.rb
+++ b/spec/resqued/config/exit_event_spec.rb
@@ -32,7 +32,7 @@ describe do
       fork do
         exit!
       end
-      status = Process.waitpid2[1]
+      _, status = Process.waitpid2
       Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(alive_time_sec: 1, process_status: status))
     }
 

--- a/spec/resqued/config/exit_event_spec.rb
+++ b/spec/resqued/config/exit_event_spec.rb
@@ -26,7 +26,11 @@ describe do
       end
     END_CONFIG
 
-    let(:evaluator) { Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(alive_time_sec: 1, process_status: Process::Status.allocate)) }
+    let(:evaluator) {
+      fork { 0 }
+      status = Process.waitpid2[1]
+      Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(alive_time_sec: 1, process_status: status))
+    }
 
     it { expect($after_exit_called).to eq(true) }
     it { expect($worker_alive_time_sec > 0).to eq(true) }

--- a/spec/resqued/config/exit_event_spec.rb
+++ b/spec/resqued/config/exit_event_spec.rb
@@ -22,13 +22,15 @@ describe do
       after_exit do |worker_summary|
         $after_exit_called = true
         $worker_alive_time_sec = worker_summary.alive_time_sec
+        $exit_status = worker_summary.process_status.exitstatus
       end
     END_CONFIG
 
-    let(:evaluator) { Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(1)) }
+    let(:evaluator) { Resqued::Config::AfterExit.new(worker_summary: Resqued::WorkerSummary.new(alive_time_sec: 1, process_status: Process::Status.allocate)) }
 
     it { expect($after_exit_called).to eq(true) }
     it { expect($worker_alive_time_sec > 0).to eq(true) }
+    it { expect($exit_status).to eq(0) }
   end
 end
 

--- a/spec/resqued/test_case_spec.rb
+++ b/spec/resqued/test_case_spec.rb
@@ -9,6 +9,7 @@ describe Resqued::TestCase do
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_clean.rb"              }.not_to raise_error }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_before_fork_raises.rb" }.to     raise_error(RuntimeError) }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_after_fork_raises.rb"  }.to     raise_error(RuntimeError) }
+    it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_after_exit_raises.rb"  }.to     raise_error(RuntimeError) }
     it { expect { test_case.assert_resqued "spec/fixtures/test_case_environment.rb", "spec/fixtures/test_case_no_workers.rb"         }.not_to raise_error }
   end
 end


### PR DESCRIPTION
When increasing worker pool size configs, memory usage can increase with concurrency, which can cause excessive worker rollover when hitting memory limits.

I thought it might be useful to expose a listener process hook `after_exit` which captures info about each exited worker to help inform the impact on worker rollover:
- `alive_time_sec`: how long the worker stayed alive for - workers should at least live as long as the average expected job lifetime
- `process_status`: the exit code / termsig information on the process status can be used to distinguish external kills (i.e. via OOM) versus graceful self shutdown.

The main benefit of doing this in the listener process as opposed to the worker process itself is tracking how long workers live on unclean exits due to external kills (i.e. SIGKILL).

cc @github/data-pipelines @spraints