### PR TITLE
Re exec only when asked

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,7 +69,6 @@ Style/Documentation:
     - 'lib/resqued/listener_pool.rb'
     - 'lib/resqued/listener_state.rb'
     - 'lib/resqued/logging.rb'
-    - 'lib/resqued/master_state.rb'
     - 'lib/resqued/procline_version.rb'
     - 'lib/resqued/quit-and-wait.rb'
     - 'lib/resqued/replace_master.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,12 +57,25 @@ Style/BlockDelimiters:
   FunctionalMethods:
     - trap
 
-# TODO - add docs to code.
 Style/Documentation:
-  Enabled: false
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
+    # TODO - add docs to these:
+    - 'lib/resqued.rb'
+    - 'lib/resqued/backoff.rb'
+    - 'lib/resqued/config.rb'
+    - 'lib/resqued/daemon.rb'
+    - 'lib/resqued/listener_pool.rb'
+    - 'lib/resqued/listener_state.rb'
+    - 'lib/resqued/logging.rb'
+    - 'lib/resqued/master_state.rb'
+    - 'lib/resqued/procline_version.rb'
+    - 'lib/resqued/quit-and-wait.rb'
+    - 'lib/resqued/replace_master.rb'
+    - 'lib/resqued/runtime_info.rb'
+    - 'lib/resqued/sleepy.rb'
+    - 'lib/resqued/test_case.rb'
 
 Style/EmptyMethod:
   EnforcedStyle: expanded

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Resqued is a multi-process daemon that controls and monitors a pool of resque workers. It works well with slow jobs and continuous delivery.
 
-[![travis status](https://travis-ci.org/spraints/resqued.png)](https://travis-ci.org/spraints/resqued)
+![CI status](https://github.com/spraints/resqued/actions/workflows/ruby.yml/badge.svg)
 
 ## Installation
 

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -8,6 +8,7 @@ Here is a summary of how signals get passed between resqued's processes:
                   master    listener    worker
                   ------    --------    ------
 restart            HUP   -> QUIT     -> QUIT
+reexec master     USR1   -> QUIT     -> QUIT
 exit now           INT   ->  INT     ->  INT
 exit now          TERM   -> TERM     -> TERM
 exit when ready   QUIT   -> QUIT     -> QUIT
@@ -23,6 +24,7 @@ Read on for more information about what the signals mean.
 The Master process handles several signals.
 
 * `HUP`: Start a new listener. After it boots, kill the previous listener with `SIGQUIT`.
+* `USR1`: Re-exec the master process, preserving the current state. Also exec a new listener.
 * `USR2`: Pause processing. Kills the current listener, and does not start a replacement.
 * `CONT`: Resume processing. If there is no listener, start one. If there is a listener, send it `SIGCONT`.
 * `QUIT`, `INT`, or `TERM`: Kill the listener with the same signal and wait for it to exit. If `--fast-exit` was specified, the master exits immediately without waiting for the listener to exit.

--- a/exe/resqued
+++ b/exe/resqued
@@ -84,7 +84,7 @@ else
   state = Resqued::MasterState.new
   if options[:master_state]
     Resqued::Logging.logger.info "Resuming master from #{options[:master_state]}"
-    Resqued::ExecOnHUP.restore_state(state, options[:master_state])
+    Resqued::ReplaceMaster.restore_state(state, options[:master_state])
   else
     require_config_paths! options, opts
     Resqued.capture_start_ctx!

--- a/exe/resqued
+++ b/exe/resqued
@@ -13,7 +13,7 @@ end
 
 require "optparse"
 
-options = { exec_on_hup: true }
+options = {}
 daemonize = false
 test = false
 
@@ -50,10 +50,6 @@ opts = OptionParser.new do |opts| # rubocop: disable Lint/ShadowingOuterLocalVar
 
   opts.on "-D", "--daemonize", "Run daemonized in the background" do
     daemonize = true
-  end
-
-  opts.on "--no-exec-on-hup", "Do not re-exec the master process on SIGHUP" do
-    options[:exec_on_hup] = false
   end
 
   opts.on "--replace FILE", "(internal)" do |v|

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -55,13 +55,12 @@ module Resqued
         when :INFO
           dump_object_counts
         when :HUP
-          if @state.exec_on_hup
-            log "Execing a new master"
-            ReplaceMaster.exec!(@state)
-          end
           reopen_logs
           log "Restarting listener with new configuration and application."
           prepare_new_listener
+        when :USR1
+          log "Execing a new master"
+          ReplaceMaster.exec!(@state)
         when :USR2
           log "Pause job processing"
           @state.paused = true
@@ -215,7 +214,7 @@ module Resqued
       end
     end
 
-    SIGNALS = [:HUP, :INT, :USR2, :CONT, :TERM, :QUIT].freeze
+    SIGNALS = [:HUP, :INT, :USR1, :USR2, :CONT, :TERM, :QUIT].freeze
     OPTIONAL_SIGNALS = [:INFO].freeze
     OTHER_SIGNALS = [:CHLD, "EXIT"].freeze
     TRAPS = SIGNALS + OPTIONAL_SIGNALS + OTHER_SIGNALS

--- a/lib/resqued/master.rb
+++ b/lib/resqued/master.rb
@@ -1,10 +1,10 @@
 require "resqued/backoff"
-require "resqued/exec_on_hup"
 require "resqued/listener_pool"
 require "resqued/logging"
 require "resqued/master_state"
 require "resqued/pidfile"
 require "resqued/procline_version"
+require "resqued/replace_master"
 require "resqued/sleepy"
 
 module Resqued
@@ -57,7 +57,7 @@ module Resqued
         when :HUP
           if @state.exec_on_hup
             log "Execing a new master"
-            ExecOnHUP.exec!(@state)
+            ReplaceMaster.exec!(@state)
           end
           reopen_logs
           log "Restarting listener with new configuration and application."

--- a/lib/resqued/replace_master.rb
+++ b/lib/resqued/replace_master.rb
@@ -2,7 +2,7 @@ require "tempfile"
 require "yaml"
 
 module Resqued
-  class ExecOnHUP
+  class ReplaceMaster
     # Public: Replace the current master process with a new one, while preserving state.
     def self.exec!(state)
       exec Resqued::START_CTX["$0"], "--replace", store_state(state), exec_opts(state)


### PR DESCRIPTION
This is a rebased copy of #53. We did have a problem where the binstub for resqued wasn't working during a deploy, and that ended up stopping all of our workers instead of failing gracefully.